### PR TITLE
强化代理协议正确性并加固本地服务安全性

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ uv run python main.py
 `config.toml` is required before running:
 
 ```toml
+[server]
+host = "127.0.0.1"                  # Recommended: keep loopback-only
+port = 5001
+reload = true
+api_key = ""                         # Optional local API key for /v0 and /v1
+cors_origins = ["*"]                 # Recommended: replace with explicit origins for browser clients
+cors_allow_credentials = false
+cors_allow_methods = ["*"]
+cors_allow_headers = ["*"]
+
 [account]
 email = "your_email@example.com"   # Email login (priority)
 mobile = ""                        # Phone login (used when email is empty)
@@ -41,7 +51,12 @@ password = "your_password"
 token = ""                         # Optional, system will auto-manage (saved after first use)
 ```
 
-**Security**: The `/v1/chat/completions` endpoint has no API token verification by default. **Always run the service on `127.0.0.1`** (default in `main.py`) to prevent unauthorized access. (Or modify to add your own token validation)
+**Security**:
+- By default, local API auth is disabled for backwards compatibility.
+- If you set `[server].api_key` or environment variable `DEEPSEEK_WEB_API_KEY`, all `/v0/*` and `/v1/*` endpoints require either `Authorization: Bearer <token>` or `X-API-Key: <token>`.
+- `main.py` now reads `[server].host`, `[server].port`, and `[server].reload`.
+- CORS is configurable via `[server].cors_*`. The default remains permissive for compatibility, but you should narrow `cors_origins` before exposing browser clients.
+- You should still run the service on `127.0.0.1` unless you intentionally expose it.
 
 ## Models
 

--- a/README.中文.md
+++ b/README.中文.md
@@ -33,6 +33,16 @@ uv run python main.py
 运行前需要配置 `config.toml`：
 
 ```toml
+[server]
+host = "127.0.0.1"                  # 建议保持 loopback，仅本机访问
+port = 5001
+reload = true
+api_key = ""                         # 可选，本地代理鉴权 token，保护 /v0 和 /v1
+cors_origins = ["*"]                 # 建议改成明确白名单
+cors_allow_credentials = false
+cors_allow_methods = ["*"]
+cors_allow_headers = ["*"]
+
 [account]
 email = "your_email@example.com"   # 邮箱登录（优先）
 mobile = ""                        # 手机号登录（email 为空时使用）
@@ -41,7 +51,12 @@ password = "your_password"
 token = ""                         # 非必须，系统会自动管理（首次使用后保存）
 ```
 
-**安全提示**：`/v1/chat/completions` 端点默认没有设置 API Token 验证。**请务必将服务运行在 `127.0.0.1`**（`main.py` 默认值），以防止未授权访问。(或者自行修改支持Token验证)
+**安全提示**：
+- 为兼容旧用法，默认不启用本地 API 鉴权。
+- 如果设置了 `[server].api_key` 或环境变量 `DEEPSEEK_WEB_API_KEY`，所有 `/v0/*` 和 `/v1/*` 请求都必须携带 `Authorization: Bearer <token>` 或 `X-API-Key: <token>`。
+- `main.py` 现在会读取 `[server].host`、`[server].port`、`[server].reload`。
+- CORS 可通过 `[server].cors_*` 配置；为了兼容旧行为，默认仍较宽松，但面向浏览器暴露时应收紧 `cors_origins`。
+- 即便如此，仍建议只监听 `127.0.0.1`（`main.py` 默认值）。
 
 ## 模型
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,16 @@
 # 日志级别: DEBUG, INFO, WARNING, ERROR
 log_level = "WARNING"
 
+[server]
+host = "127.0.0.1"  # 建议保持 loopback，仅本机访问
+port = 5001
+reload = true
+api_key = ""  # 可选，本地代理鉴权。设置后，/v0 和 /v1 请求需携带 Bearer token 或 X-API-Key
+cors_origins = ["*"]  # 生产环境建议改成明确白名单
+cors_allow_credentials = false
+cors_allow_methods = ["*"]
+cors_allow_headers = ["*"]
+
 [account]
 email = "your_email@example.com"  # 邮箱登录（优先）
 mobile = ""                        # 手机号登录（email 为空时使用）

--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
 import uvicorn
+from src.deepseek_web_api.core.config import (
+    get_server_host,
+    get_server_port,
+    get_server_reload,
+)
 
 if __name__ == "__main__":
     uvicorn.run(
         "src.deepseek_web_api:app",
-        host="127.0.0.1",
-        port=5001,
-        reload=True,
+        host=get_server_host(),
+        port=get_server_port(),
+        reload=get_server_reload(),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+curl-cffi>=0.14.0
+fastapi>=0.135.1
+httpx>=0.28.1
+python-multipart>=0.0.22
+tomli-w>=1.2.0
+uvicorn>=0.42.0
+wasmtime>=42.0.0

--- a/src/deepseek_web_api/__init__.py
+++ b/src/deepseek_web_api/__init__.py
@@ -3,9 +3,11 @@
 from .api.routes import app
 from .api.openai import models_router, chat_completions_router
 from .core.logger import setup_logger
+from .core.server_security import log_startup_security_warnings
 
 # Setup centralized logger (level configured in config.toml or default WARNING)
 setup_logger()
+log_startup_security_warnings()
 
 # Include OpenAI compatible routers
 app.include_router(models_router)

--- a/src/deepseek_web_api/api/openai/chat_completions/route.py
+++ b/src/deepseek_web_api/api/openai/chat_completions/route.py
@@ -30,6 +30,17 @@ class ChatCompletionRequest(BaseModel):
     tools: Optional[List[dict]] = None
 
 
+def _stream_error_chunks(message: str):
+    error_payload = {
+        "error": {
+            "message": message,
+            "type": "server_error",
+        }
+    }
+    yield f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
 @router.post("/v1/chat/completions")
 async def chat_completions(request: Request):
     """OpenAI-compatible /v1/chat/completions endpoint.
@@ -53,7 +64,7 @@ async def chat_completions(request: Request):
 
     # Model-specific overrides: reasoning model gets thinking, others don't
     thinking_enabled = "reasoner" in validated.model
-    search_enabled = False
+    search_enabled = validated.search_enabled
 
     pool = await get_pool()
 
@@ -65,7 +76,15 @@ async def chat_completions(request: Request):
         async def stream_with_pool():
             """Generator that acquires session from pool, streams, and releases."""
             for session_retry in range(_MAX_SESSION_RETRIES):
-                session = await pool.acquire()
+                try:
+                    session = await pool.acquire()
+                except Exception as e:
+                    logger.error(f"[stream] failed to acquire session: {e}")
+                    async for chunk in _emit_stream_error(
+                        f"Failed to create DeepSeek session: {type(e).__name__}"
+                    ):
+                        yield chunk
+                    return
                 logger.info(f"[stream] acquired session {session.chat_session_id[:8]}..., is_initialized={session.is_initialized}")
 
                 buffered = []
@@ -133,9 +152,15 @@ async def chat_completions(request: Request):
 
     # Non-streaming: buffer all chunks first, then return
     last_exc = None
+    chunks = []
 
     for session_retry in range(_MAX_SESSION_RETRIES):
-        session = await pool.acquire()
+        try:
+            session = await pool.acquire()
+        except Exception as e:
+            last_exc = e
+            logger.error(f"[non-stream] failed to acquire session: {e}")
+            break
         logger.info(f"[non-stream] acquired session {session.chat_session_id[:8]}..., is_initialized={session.is_initialized}")
 
         chunks = []
@@ -163,7 +188,9 @@ async def chat_completions(request: Request):
 
     # If all retries failed, raise the last exception
     if not chunks:
-        raise last_exc
+        if last_exc is not None:
+            raise last_exc
+        raise HTTPException(status_code=502, detail="DeepSeek returned no completion chunks")
 
     # Parse buffered chunks
     content_chunks = []
@@ -214,3 +241,8 @@ async def chat_completions(request: Request):
             "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
         }
     )
+
+
+async def _emit_stream_error(message: str):
+    for chunk in _stream_error_chunks(message):
+        yield chunk

--- a/src/deepseek_web_api/api/openai/chat_completions/service.py
+++ b/src/deepseek_web_api/api/openai/chat_completions/service.py
@@ -21,6 +21,17 @@ from .tools import (
 )
 
 
+def _extract_complete_sse_events(buffer: str) -> tuple[list[str], str]:
+    """Extract complete SSE events from a cumulative buffer."""
+    normalized = buffer.replace("\r\n", "\n")
+    events = []
+    while "\n\n" in normalized:
+        event, normalized = normalized.split("\n\n", 1)
+        if event.strip():
+            events.append(event)
+    return events, normalized
+
+
 async def stream_generator(
     prompt: str,
     model_name: str,
@@ -78,7 +89,9 @@ async def stream_generator(
     in_tool_buffer = False
     had_tool_call = False
     force_end = False  # Flag to indicate we should stop yielding to client after tool calls
+    client_stream_closed = False
     extra_prefix = ""  # Prefetched content from edit_message nested dict format
+    sse_buffer = ""
 
     async for line in stream_func(
         prompt=prompt,
@@ -86,12 +99,11 @@ async def stream_generator(
         search_enabled=search_enabled,
         thinking_enabled=thinking_enabled,
     ):
-        # Handle bytes from proxy_to_deepseek_stream
         if isinstance(line, bytes):
             line = line.decode("utf-8")
 
-        # Split by \n\n first to separate SSE events
-        events = line.split("\n\n")
+        sse_buffer += line
+        events, sse_buffer = _extract_complete_sse_events(sse_buffer)
         for raw_event in events:
             raw_event = raw_event.strip()
             if not raw_event:
@@ -240,6 +252,7 @@ async def stream_generator(
                                         yield "data: [DONE]\n\n"
                                         logger.debug("Tool calls parsed, forcing stream end")
                                         force_end = True
+                                        client_stream_closed = True
                                 # Even if parsing failed, we still force end at [/TOOL🛠️]
                                 if force_end:
                                     # Continue consuming remaining data but don't yield to client
@@ -253,10 +266,11 @@ async def stream_generator(
                     # reasoning mode
                     yield make_chunk(reasoning=v)
 
-    # Send finish reason
-    yield make_chunk(finish_reason="tool_calls" if had_tool_call else "stop")
-    logger.debug("Yielding [DONE]")
-    yield "data: [DONE]\n\n"
+    if not client_stream_closed:
+        # Send finish reason once unless we already closed the client stream on tool_calls
+        yield make_chunk(finish_reason="tool_calls" if had_tool_call else "stop")
+        logger.debug("Yielding [DONE]")
+        yield "data: [DONE]\n\n"
 
     # Mark session as initialized after successful completion (message_id=1 now exists)
     if session and not session.is_initialized:

--- a/src/deepseek_web_api/api/openai/chat_completions/session_pool.py
+++ b/src/deepseek_web_api/api/openai/chat_completions/session_pool.py
@@ -143,6 +143,19 @@ class StatelessSessionPool:
 
             for sid in to_remove:
                 del self._sessions[sid]
+
+        if to_remove:
+            from ...v0_service import delete_session as delete_remote_session
+
+            for sid in to_remove:
+                try:
+                    resp = await delete_remote_session(sid)
+                    if resp.status_code >= 400:
+                        logger.warning(
+                            f"[pool] remote cleanup for session {sid[:8]}... returned {resp.status_code}"
+                        )
+                except Exception as e:
+                    logger.warning(f"[pool] failed to delete remote session {sid[:8]}...: {e}")
                 removed += 1
                 logger.info(f"[pool] removed idle session {sid[:8]}...")
 

--- a/src/deepseek_web_api/api/routes.py
+++ b/src/deepseek_web_api/api/routes.py
@@ -2,10 +2,19 @@
 
 import logging
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
+from ..core.config import (
+    get_cors_allow_credentials,
+    get_cors_allow_headers,
+    get_cors_allow_methods,
+    get_cors_origin_regex,
+    get_cors_origins,
+)
 from ..core.logger import logger
+from ..core.local_api_auth import requires_local_api_auth, verify_local_api_auth
 from fastapi.responses import StreamingResponse
 
 from .v0_service import (
@@ -22,15 +31,38 @@ from .v0_service import (
 
 logger = logging.getLogger("deepseek_web_api")
 
+
+def get_cors_middleware_options() -> dict:
+    options = {
+        "allow_origins": get_cors_origins(),
+        "allow_credentials": get_cors_allow_credentials(),
+        "allow_methods": get_cors_allow_methods(),
+        "allow_headers": get_cors_allow_headers(),
+    }
+    origin_regex = get_cors_origin_regex()
+    if origin_regex:
+        options["allow_origin_regex"] = origin_regex
+    return options
+
+
 app = FastAPI()
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+app.add_middleware(CORSMiddleware, **get_cors_middleware_options())
+
+
+@app.middleware("http")
+async def local_api_auth_middleware(request: Request, call_next):
+    """Protect /v0 and /v1 endpoints with optional local API key auth."""
+    if requires_local_api_auth(request.url.path):
+        try:
+            verify_local_api_auth(request)
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=getattr(exc, "headers", None),
+            )
+    return await call_next(request)
 
 
 @app.api_route("/v0/chat/completion", methods=["POST"])

--- a/src/deepseek_web_api/api/v0_service.py
+++ b/src/deepseek_web_api/api/v0_service.py
@@ -9,7 +9,7 @@ from typing import Any
 import httpx
 from fastapi import Response
 
-from ..core.auth import get_auth_headers
+from ..core.auth import get_auth_headers, invalidate_token
 from ..core.pow import get_pow_response
 from ..core.parent_msg_store import ParentMsgStore
 from ..core.config import DEEPSEEK_HOST
@@ -26,6 +26,17 @@ _PATH_FETCH_FILES = "api/v0/file/fetch_files"
 _PATH_HISTORY_MESSAGES = "api/v0/chat/history_messages"
 
 DEEPSEEK_BASE_URL = f"https://{DEEPSEEK_HOST}"
+
+
+def _response_indicates_invalid_token(content: bytes) -> bool:
+    """Return True if DeepSeek response payload indicates token invalidation."""
+    if not content:
+        return False
+    try:
+        data = json.loads(content)
+    except Exception:
+        return False
+    return data.get("code") == 40003
 
 
 def parse_sse_response_message_id(content: bytes) -> int | None:
@@ -55,31 +66,39 @@ async def proxy_to_deepseek(
     """Proxy request to DeepSeek backend, return FastAPI Response."""
     url = f"{DEEPSEEK_BASE_URL}/{path}"
     logger.debug(f"[proxy] {method} {path}")
-    auth_headers = get_auth_headers()
-    if headers:
-        headers = {**headers, **auth_headers}
-    else:
-        headers = auth_headers
-    headers["Host"] = DEEPSEEK_HOST
-
-    if files is not None and "Content-Type" in headers:
-        del headers["Content-Type"]
+    max_retries = 2
 
     async with httpx.AsyncClient(timeout=120.0) as client:
-        resp = await client.request(
-            method=method,
-            url=url,
-            headers=headers,
-            json=json_data,
-            params=params,
-            content=content,
-            files=files,
-        )
-        return Response(
-            content=resp.content,
-            status_code=resp.status_code,
-            headers=dict(resp.headers),
-        )
+        for attempt in range(max_retries):
+            auth_headers = get_auth_headers()
+            merged_headers = {**headers, **auth_headers} if headers else auth_headers
+            merged_headers["Host"] = DEEPSEEK_HOST
+
+            if files is not None and "Content-Type" in merged_headers:
+                del merged_headers["Content-Type"]
+
+            resp = await client.request(
+                method=method,
+                url=url,
+                headers=merged_headers,
+                json=json_data,
+                params=params,
+                content=content,
+                files=files,
+            )
+
+            if _response_indicates_invalid_token(resp.content) and attempt < max_retries - 1:
+                logger.warning(f"[proxy] token invalid on {path}, refreshing token and retrying...")
+                invalidate_token()
+                continue
+
+            return Response(
+                content=resp.content,
+                status_code=resp.status_code,
+                headers=dict(resp.headers),
+            )
+
+        return Response(content=b"", status_code=502)
 
 
 async def proxy_to_deepseek_stream(
@@ -111,11 +130,12 @@ async def proxy_to_deepseek_stream(
                 yield chunk
 
 
-async def delete_session(chat_session_id: str) -> None:
+async def delete_session(chat_session_id: str) -> Response:
     """Delete session from DeepSeek backend and clean up local store."""
     max_retries = 5
     retry_delay = 0.5
     last_exc = None
+    last_resp = None
 
     for attempt in range(max_retries):
         try:
@@ -124,6 +144,7 @@ async def delete_session(chat_session_id: str) -> None:
                 _PATH_DELETE_SESSION,
                 json_data={"chat_session_id": chat_session_id},
             )
+            last_resp = resp
             logger.info(f"[delete_session] attempt {attempt+1}: status={resp.status_code}")
 
             # Check biz_code from delete response
@@ -160,6 +181,25 @@ async def delete_session(chat_session_id: str) -> None:
     # Always clean up local store, regardless of backend result
     await ParentMsgStore.get_instance().adelete(chat_session_id)
 
+    if last_resp is not None:
+        return last_resp
+
+    return Response(
+        content=json.dumps(
+            {
+                "code": -1,
+                "msg": "Failed to delete session after retries",
+                "data": {
+                    "biz_code": -1,
+                    "biz_msg": str(last_exc) if last_exc else "unknown error",
+                    "biz_data": None,
+                },
+            }
+        ),
+        status_code=502,
+        media_type="application/json",
+    )
+
 
 async def create_session(body: dict = None) -> tuple[str | None, Response]:
     """Create new session and return (session_id, response).
@@ -183,7 +223,21 @@ async def create_session(body: dict = None) -> tuple[str | None, Response]:
     if resp.body:
         try:
             data = json.loads(resp.body)
-            chat_session_id = data.get("data", {}).get("biz_data", {}).get("id")
+            payload = data.get("data")
+            if not isinstance(payload, dict):
+                logger.warning(
+                    f"[create_session] backend returned unexpected payload: status={resp.status_code}, body={resp.body[:300]!r}"
+                )
+                return None, resp
+
+            biz_data = payload.get("biz_data")
+            if not isinstance(biz_data, dict):
+                logger.warning(
+                    f"[create_session] backend returned unexpected biz_data: status={resp.status_code}, body={resp.body[:300]!r}"
+                )
+                return None, resp
+
+            chat_session_id = biz_data.get("id")
             if chat_session_id:
                 await ParentMsgStore.get_instance().acreate(chat_session_id)
                 data["chat_session_id"] = chat_session_id

--- a/src/deepseek_web_api/core/config.py
+++ b/src/deepseek_web_api/core/config.py
@@ -53,6 +53,42 @@ def save_config(cfg):
 
 CONFIG = load_config()
 
+
+def _get_server_config() -> dict:
+    return CONFIG.get("server", {})
+
+
+def _get_env_or_config(env_name: str, config_key: str, default):
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        return env_value
+    return _get_server_config().get(config_key, default)
+
+
+def _parse_bool(value, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _parse_csv_or_list(value, default: list[str]) -> list[str]:
+    if value is None:
+        return list(default)
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        items = [item.strip() for item in value.split(",")]
+        return [item for item in items if item]
+    return list(default)
+
 # ----------------------------------------------------------------------
 # (2) DeepSeek API constants
 # ----------------------------------------------------------------------
@@ -75,3 +111,62 @@ WASM_PATH = os.getenv("WASM_PATH", str(_default_wasm))
 # Log level from config (default WARNING if not set)
 _log_level_str = CONFIG.get("log_level", "WARNING").upper()
 LOG_LEVEL = getattr(logging, _log_level_str, logging.WARNING)
+
+
+def get_local_api_key() -> str:
+    """Get optional local API key for protecting this proxy service.
+
+    Environment variable takes precedence over config.toml.
+    """
+    env_key = os.getenv("DEEPSEEK_WEB_API_KEY", "").strip()
+    if env_key:
+        return env_key
+
+    server_cfg = _get_server_config()
+    return str(server_cfg.get("api_key", "")).strip()
+
+
+def get_server_host() -> str:
+    return str(_get_env_or_config("DEEPSEEK_WEB_HOST", "host", "127.0.0.1")).strip()
+
+
+def get_server_port() -> int:
+    return int(_get_env_or_config("DEEPSEEK_WEB_PORT", "port", 5001))
+
+
+def get_server_reload() -> bool:
+    return _parse_bool(_get_env_or_config("DEEPSEEK_WEB_RELOAD", "reload", True), True)
+
+
+def get_cors_origins() -> list[str]:
+    return _parse_csv_or_list(
+        _get_env_or_config("DEEPSEEK_WEB_CORS_ORIGINS", "cors_origins", ["*"]),
+        ["*"],
+    )
+
+
+def get_cors_origin_regex() -> str | None:
+    value = _get_env_or_config("DEEPSEEK_WEB_CORS_ORIGIN_REGEX", "cors_origin_regex", "")
+    value = str(value).strip()
+    return value or None
+
+
+def get_cors_allow_credentials() -> bool:
+    return _parse_bool(
+        _get_env_or_config("DEEPSEEK_WEB_CORS_ALLOW_CREDENTIALS", "cors_allow_credentials", False),
+        False,
+    )
+
+
+def get_cors_allow_methods() -> list[str]:
+    return _parse_csv_or_list(
+        _get_env_or_config("DEEPSEEK_WEB_CORS_ALLOW_METHODS", "cors_allow_methods", ["*"]),
+        ["*"],
+    )
+
+
+def get_cors_allow_headers() -> list[str]:
+    return _parse_csv_or_list(
+        _get_env_or_config("DEEPSEEK_WEB_CORS_ALLOW_HEADERS", "cors_allow_headers", ["*"]),
+        ["*"],
+    )

--- a/src/deepseek_web_api/core/local_api_auth.py
+++ b/src/deepseek_web_api/core/local_api_auth.py
@@ -1,0 +1,40 @@
+"""Local API authentication for protecting this proxy service."""
+
+from fastapi import HTTPException, Request, status
+
+from .config import get_local_api_key
+
+
+def _extract_request_token(request: Request) -> str:
+    """Extract API token from Authorization or X-API-Key headers."""
+    x_api_key = request.headers.get("x-api-key", "").strip()
+    if x_api_key:
+        return x_api_key
+
+    authorization = request.headers.get("authorization", "").strip()
+    if authorization.lower().startswith("bearer "):
+        return authorization[7:].strip()
+
+    return ""
+
+
+def requires_local_api_auth(path: str) -> bool:
+    """Return True when the request path should be protected."""
+    return path.startswith("/v0") or path.startswith("/v1")
+
+
+def verify_local_api_auth(request: Request) -> None:
+    """Validate local API auth when an API key is configured."""
+    expected_token = get_local_api_key()
+    if not expected_token:
+        return
+
+    provided_token = _extract_request_token(request)
+    if provided_token == expected_token:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or missing local API key",
+        headers={"WWW-Authenticate": "Bearer"},
+    )

--- a/src/deepseek_web_api/core/server_security.py
+++ b/src/deepseek_web_api/core/server_security.py
@@ -1,0 +1,38 @@
+"""Server-side security warnings for local deployment."""
+
+from .config import get_cors_origins, get_local_api_key, get_server_host
+from .logger import logger
+
+
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower().strip("[]")
+    return normalized in _LOOPBACK_HOSTS
+
+
+def collect_startup_security_warnings() -> list[str]:
+    host = get_server_host()
+    api_key = get_local_api_key()
+    cors_origins = get_cors_origins()
+
+    warnings = []
+    if not api_key:
+        warnings.append("Local API auth is disabled; /v0 and /v1 are usable by any caller that can reach this service.")
+
+    if "*" in cors_origins:
+        warnings.append("CORS allows all origins; narrow [server].cors_origins before exposing browser clients.")
+
+    if not is_loopback_host(host):
+        warnings.append(f"Server host is {host}, not loopback; this service may be reachable from other machines.")
+
+    if not is_loopback_host(host) and not api_key:
+        warnings.append("Non-loopback binding without local API auth is unsafe for shared networks or public hosts.")
+
+    return warnings
+
+
+def log_startup_security_warnings() -> None:
+    for warning in collect_startup_security_warnings():
+        logger.warning(f"[security] {warning}")

--- a/tests/api/test_chat_completions/test_route.py
+++ b/tests/api/test_chat_completions/test_route.py
@@ -1,0 +1,141 @@
+"""Unit tests for chat_completions route behavior."""
+
+import json
+import sys
+
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.insert(0, "src")
+
+from deepseek_web_api import app
+from deepseek_web_api.api.openai.chat_completions.session_pool import StatelessSession
+
+
+class _FakePool:
+    def __init__(self):
+        self.session = StatelessSession(chat_session_id="session-123")
+        self.release_calls = []
+
+    async def acquire(self):
+        return self.session
+
+    async def release(self, session, error=False):
+        self.release_calls.append((session, error))
+
+    async def cleanup_idle(self):
+        return 0
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestChatCompletionsRoute:
+    def test_non_streaming_respects_search_enabled(self, client, monkeypatch):
+        captured = {}
+        fake_pool = _FakePool()
+
+        async def fake_get_pool():
+            return fake_pool
+
+        async def fake_stream_generator(prompt, model_name, search_enabled, thinking_enabled, tools, session):
+            captured["search_enabled"] = search_enabled
+            yield (
+                'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n'
+            )
+            yield "data: [DONE]\n\n"
+
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.route.get_pool",
+            fake_get_pool,
+        )
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.route.stream_generator",
+            fake_stream_generator,
+        )
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-web-chat",
+                "messages": [{"role": "user", "content": "hello"}],
+                "search_enabled": True,
+                "stream": False,
+            },
+        )
+
+        assert response.status_code == 200
+        assert captured["search_enabled"] is True
+
+    def test_non_streaming_empty_chunks_returns_502(self, client, monkeypatch):
+        fake_pool = _FakePool()
+
+        async def fake_get_pool():
+            return fake_pool
+
+        async def empty_stream_generator(prompt, model_name, search_enabled, thinking_enabled, tools, session):
+            if False:
+                yield None
+
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.route.get_pool",
+            fake_get_pool,
+        )
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.route.stream_generator",
+            empty_stream_generator,
+        )
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-web-chat",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+        )
+
+        assert response.status_code == 502
+        assert response.json()["detail"] == "DeepSeek returned no completion chunks"
+
+    def test_streaming_acquire_failure_returns_sse_error(self, client, monkeypatch):
+        class FailingPool:
+            async def acquire(self):
+                raise RuntimeError("create session failed")
+
+            async def release(self, session, error=False):
+                return None
+
+            async def cleanup_idle(self):
+                return 0
+
+        async def fake_get_pool():
+            return FailingPool()
+
+        monkeypatch.setattr(
+            "deepseek_web_api.core.local_api_auth.get_local_api_key",
+            lambda: "",
+        )
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.route.get_pool",
+            fake_get_pool,
+        )
+
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-web-chat",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        ) as response:
+            body = response.read().decode("utf-8")
+
+        assert response.status_code == 200
+        parts = [part for part in body.split("\n\n") if part]
+        error_payload = json.loads(parts[0][6:])
+        assert error_payload["error"]["message"].startswith("Failed to create DeepSeek session")
+        assert parts[-1] == "data: [DONE]"

--- a/tests/api/test_chat_completions/test_service.py
+++ b/tests/api/test_chat_completions/test_service.py
@@ -1,60 +1,134 @@
-"""Unit tests for service.py - stream generation service.
-
-Note: These tests are limited because mocking async generator imports is complex.
-The service is tested indirectly through integration/smoke tests.
-"""
+"""Unit tests for service.py - stream generation service."""
 
 import json
 import sys
-from unittest.mock import MagicMock
 
 import pytest
 
 sys.path.insert(0, "src")
 
+from deepseek_web_api.api.openai.chat_completions.service import (
+    _extract_complete_sse_events,
+    stream_generator,
+)
+from deepseek_web_api.api.openai.chat_completions.session_pool import StatelessSession
 
-class TestStreamGeneratorHelpers:
-    """Tests for stream_generator helper functions and behavior."""
 
-    def test_make_sse_chunk_format(self):
-        """Test SSE chunk formatting helper."""
-        from deepseek_web_api.api.openai.chat_completions.service import stream_generator
+def _parse_sse_chunk(chunk: str) -> dict | None:
+    if chunk == "data: [DONE]\n\n":
+        return None
+    return json.loads(chunk[6:])
 
-        # We can't easily test the full stream_generator without mocking,
-        # but we can verify the module imports correctly
-        assert stream_generator is not None
 
-    def test_service_module_imports(self):
-        """Test that service module imports correctly."""
-        from deepseek_web_api.api.openai.chat_completions import service
-        assert hasattr(service, 'stream_generator')
-        assert hasattr(service, 'TOOL_START_MARKER')
-        assert hasattr(service, 'TOOL_END_MARKER')
+class TestSseHelpers:
+    """Tests for SSE buffering helpers."""
+
+    def test_extract_complete_sse_events_preserves_partial_chunks(self):
+        events, rest = _extract_complete_sse_events('data: {"p":"response/content","v":"Hel')
+        assert events == []
+        assert rest == 'data: {"p":"response/content","v":"Hel'
+
+        events, rest = _extract_complete_sse_events(rest + 'lo"}\n\ndata: {"p":"response/status","v":"FINISHED"}\n\n')
+        assert events == [
+            'data: {"p":"response/content","v":"Hello"}',
+            'data: {"p":"response/status","v":"FINISHED"}',
+        ]
+        assert rest == ""
+
+
+class TestStreamGenerator:
+    """Tests for stream_generator behavior."""
 
     @pytest.mark.asyncio
-    async def test_session_none_uses_completion(self):
-        """Test that None session uses stream_chat_completion (completion path)."""
-        # This is a smoke test - just verify the code path doesn't crash
-        # when session is None
-        from deepseek_web_api.api.openai.chat_completions.service import stream_generator
+    async def test_stream_generator_handles_split_sse_events(self, monkeypatch):
+        async def fake_stream_chat_completion(**kwargs):
+            yield b'data: {"p":"response/content","v":"Hel'
+            yield b'lo"}\n\ndata: {"p":"response/status","v":"FIN'
+            yield b'ISHED"}\n\n'
 
-        # We can't fully test without mocking, but we can at least
-        # verify the function exists and has the right signature
-        import inspect
-        sig = inspect.signature(stream_generator)
-        params = list(sig.parameters.keys())
-        assert params == ['prompt', 'model_name', 'search_enabled', 'thinking_enabled', 'tools', 'session']
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.service.stream_chat_completion",
+            fake_stream_chat_completion,
+        )
 
-    def test_make_chunk_function_behavior(self):
-        """Test that make_chunk produces correct output format."""
-        # This tests the chunk creation logic by examining the code path
-        from deepseek_web_api.api.openai.chat_completions.service import stream_generator
-        import deepseek_web_api.api.openai.chat_completions.service as service_module
+        session = StatelessSession(chat_session_id="session-1", is_initialized=False)
+        chunks = [
+            chunk
+            async for chunk in stream_generator(
+                "hello",
+                "deepseek-web-chat",
+                search_enabled=False,
+                thinking_enabled=True,
+                tools=None,
+                session=session,
+            )
+        ]
 
-        # Access the make_chunk function indirectly through code inspection
-        import inspect
-        source = inspect.getsource(service_module.stream_generator)
+        payloads = [_parse_sse_chunk(chunk) for chunk in chunks if chunk != "data: [DONE]\n\n"]
+        content = "".join(
+            payload["choices"][0]["delta"].get("content") or ""
+            for payload in payloads
+        )
+        finish_reasons = [
+            payload["choices"][0].get("finish_reason")
+            for payload in payloads
+            if payload["choices"][0].get("finish_reason")
+        ]
 
-        # Verify make_chunk is defined in the function and produces correct format
-        assert 'data: {json.dumps' in source
-        assert 'chat.completion.chunk' in source
+        assert content == "Hello"
+        assert finish_reasons == ["stop"]
+        assert chunks.count("data: [DONE]\n\n") == 1
+        assert session.is_initialized is True
+
+    @pytest.mark.asyncio
+    async def test_stream_generator_sends_single_done_for_tool_calls(self, monkeypatch):
+        tool_payload = (
+            '[TOOL🛠️]{"name":"get_weather","arguments":{"city":"Beijing"}}[/TOOL🛠️]'
+        )
+
+        async def fake_stream_chat_completion(**kwargs):
+            yield f'data: {json.dumps({"p": "response/content", "v": tool_payload}, ensure_ascii=False)}\n\n'.encode()
+            yield b'data: {"p":"response/status","v":"FINISHED"}\n\n'
+
+        monkeypatch.setattr(
+            "deepseek_web_api.api.openai.chat_completions.service.stream_chat_completion",
+            fake_stream_chat_completion,
+        )
+
+        session = StatelessSession(chat_session_id="session-2", is_initialized=False)
+        chunks = [
+            chunk
+            async for chunk in stream_generator(
+                "weather",
+                "deepseek-web-chat",
+                search_enabled=False,
+                thinking_enabled=True,
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                        },
+                    }
+                ],
+                session=session,
+            )
+        ]
+
+        payloads = [_parse_sse_chunk(chunk) for chunk in chunks if chunk != "data: [DONE]\n\n"]
+        finish_reasons = [
+            payload["choices"][0].get("finish_reason")
+            for payload in payloads
+            if payload["choices"][0].get("finish_reason")
+        ]
+        tool_calls = [
+            tool_call
+            for payload in payloads
+            for tool_call in payload["choices"][0]["delta"].get("tool_calls", [])
+        ]
+
+        assert chunks.count("data: [DONE]\n\n") == 1
+        assert finish_reasons == ["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"]["name"] == "get_weather"

--- a/tests/api/test_chat_completions/test_session_pool.py
+++ b/tests/api/test_chat_completions/test_session_pool.py
@@ -101,7 +101,10 @@ class TestStatelessSessionPool:
         assert session.last_access_time >= original_time
 
     @pytest.mark.asyncio
-    async def test_cleanup_idle_removes_old_sessions(self, pool):
+    @patch("deepseek_web_api.api.v0_service.delete_session", new_callable=AsyncMock)
+    async def test_cleanup_idle_removes_old_sessions(self, mock_delete_session, pool):
+        mock_delete_session.return_value.status_code = 200
+
         old_session = StatelessSession(chat_session_id="old-session")
         old_session.last_access_time = time.time() - 100
         pool._sessions["old-session"] = old_session
@@ -113,9 +116,11 @@ class TestStatelessSessionPool:
         assert removed == 1
         assert "old-session" not in pool._sessions
         assert "new-session" in pool._sessions
+        mock_delete_session.assert_awaited_once_with("old-session")
 
     @pytest.mark.asyncio
-    async def test_cleanup_does_not_remove_locked_sessions(self, pool):
+    @patch("deepseek_web_api.api.v0_service.delete_session", new_callable=AsyncMock)
+    async def test_cleanup_does_not_remove_locked_sessions(self, mock_delete_session, pool):
         session = StatelessSession(chat_session_id="locked-session")
         await session.lock.acquire()
         session.last_access_time = time.time() - 100
@@ -124,11 +129,14 @@ class TestStatelessSessionPool:
         removed = await pool.cleanup_idle()
         assert removed == 0
         assert "locked-session" in pool._sessions
+        mock_delete_session.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_cleanup_idle_empty_pool(self, pool):
+    @patch("deepseek_web_api.api.v0_service.delete_session", new_callable=AsyncMock)
+    async def test_cleanup_idle_empty_pool(self, mock_delete_session, pool):
         removed = await pool.cleanup_idle()
         assert removed == 0
+        mock_delete_session.assert_not_awaited()
 
     def test_size_property(self, pool):
         pool._sessions["a"] = StatelessSession(chat_session_id="a")
@@ -181,8 +189,11 @@ class TestStatelessSessionPool:
         assert pool._cleanup_task is None
 
     @pytest.mark.asyncio
-    async def test_cleanup_loop_removes_idle_sessions(self, pool):
+    @patch("deepseek_web_api.api.v0_service.delete_session", new_callable=AsyncMock)
+    async def test_cleanup_loop_removes_idle_sessions(self, mock_delete_session, pool):
         """Test that the cleanup loop actually removes idle sessions."""
+        mock_delete_session.return_value.status_code = 200
+
         # Add a session that will be considered idle
         old_session = StatelessSession(chat_session_id="old-session")
         old_session.last_access_time = time.time() - 100
@@ -199,9 +210,11 @@ class TestStatelessSessionPool:
 
         # Session should be removed
         assert "old-session" not in pool._sessions
+        mock_delete_session.assert_awaited_once_with("old-session")
 
     @pytest.mark.asyncio
-    async def test_cleanup_loop_keeps_active_sessions(self, pool):
+    @patch("deepseek_web_api.api.v0_service.delete_session", new_callable=AsyncMock)
+    async def test_cleanup_loop_keeps_active_sessions(self, mock_delete_session, pool):
         """Test that the cleanup loop does not remove active sessions."""
         # Add an active session (recently accessed)
         active_session = StatelessSession(chat_session_id="active-session")
@@ -217,6 +230,22 @@ class TestStatelessSessionPool:
 
         # Active session should still be there
         assert "active-session" in pool._sessions
+        mock_delete_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.delete_session", new_callable=AsyncMock)
+    async def test_cleanup_idle_logs_remote_delete_failures_but_still_removes(self, mock_delete_session, pool):
+        mock_delete_session.side_effect = RuntimeError("cleanup failed")
+
+        old_session = StatelessSession(chat_session_id="old-session")
+        old_session.last_access_time = time.time() - 100
+        pool._sessions["old-session"] = old_session
+
+        removed = await pool.cleanup_idle()
+
+        assert removed == 1
+        assert "old-session" not in pool._sessions
+        mock_delete_session.assert_awaited_once_with("old-session")
 
 
 class TestGetPool:

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -1,0 +1,114 @@
+"""Tests for API route-level middleware and auth behavior."""
+
+import sys
+
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.insert(0, "src")
+
+from deepseek_web_api import app
+from deepseek_web_api.api import routes
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestLocalApiAuthMiddleware:
+    def test_root_endpoint_is_not_protected(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "deepseek_web_api.core.local_api_auth.get_local_api_key",
+            lambda: "secret-token",
+        )
+
+        response = client.get("/")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+
+    def test_v1_models_requires_auth_when_api_key_configured(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "deepseek_web_api.core.local_api_auth.get_local_api_key",
+            lambda: "secret-token",
+        )
+
+        response = client.get("/v1/models")
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or missing local API key"
+
+    def test_v1_models_accepts_bearer_token(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "deepseek_web_api.core.local_api_auth.get_local_api_key",
+            lambda: "secret-token",
+        )
+
+        response = client.get(
+            "/v1/models",
+            headers={"Authorization": "Bearer secret-token"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["object"] == "list"
+
+    def test_v1_models_accepts_x_api_key(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "deepseek_web_api.core.local_api_auth.get_local_api_key",
+            lambda: "secret-token",
+        )
+
+        response = client.get(
+            "/v1/models",
+            headers={"X-API-Key": "secret-token"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["object"] == "list"
+
+    def test_v1_models_remains_open_when_api_key_not_configured(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "deepseek_web_api.core.local_api_auth.get_local_api_key",
+            lambda: "",
+        )
+
+        response = client.get("/v1/models")
+
+        assert response.status_code == 200
+        assert response.json()["object"] == "list"
+
+
+class TestCorsConfiguration:
+    def test_get_cors_middleware_options_uses_config_helpers(self, monkeypatch):
+        monkeypatch.setattr(routes, "get_cors_origins", lambda: ["http://localhost:3000"])
+        monkeypatch.setattr(routes, "get_cors_allow_credentials", lambda: True)
+        monkeypatch.setattr(routes, "get_cors_allow_methods", lambda: ["GET", "POST"])
+        monkeypatch.setattr(routes, "get_cors_allow_headers", lambda: ["Authorization", "Content-Type"])
+        monkeypatch.setattr(routes, "get_cors_origin_regex", lambda: "^https://.*\\.example\\.com$")
+
+        options = routes.get_cors_middleware_options()
+
+        assert options == {
+            "allow_origins": ["http://localhost:3000"],
+            "allow_credentials": True,
+            "allow_methods": ["GET", "POST"],
+            "allow_headers": ["Authorization", "Content-Type"],
+            "allow_origin_regex": "^https://.*\\.example\\.com$",
+        }
+
+    def test_get_cors_middleware_options_omits_regex_when_empty(self, monkeypatch):
+        monkeypatch.setattr(routes, "get_cors_origins", lambda: ["*"])
+        monkeypatch.setattr(routes, "get_cors_allow_credentials", lambda: False)
+        monkeypatch.setattr(routes, "get_cors_allow_methods", lambda: ["*"])
+        monkeypatch.setattr(routes, "get_cors_allow_headers", lambda: ["*"])
+        monkeypatch.setattr(routes, "get_cors_origin_regex", lambda: None)
+
+        options = routes.get_cors_middleware_options()
+
+        assert options == {
+            "allow_origins": ["*"],
+            "allow_credentials": False,
+            "allow_methods": ["*"],
+            "allow_headers": ["*"],
+        }

--- a/tests/api/test_v0_service.py
+++ b/tests/api/test_v0_service.py
@@ -87,6 +87,39 @@ class TestProxyToDeepseek:
         call_kwargs = mock_client.request.call_args[1]
         assert "Content-Type" not in call_kwargs["headers"]
 
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.invalidate_token")
+    @patch("deepseek_web_api.api.v0_service.get_auth_headers")
+    @patch("deepseek_web_api.api.v0_service.httpx.AsyncClient")
+    async def test_proxy_retries_when_token_is_invalid(
+        self, mock_client_class, mock_get_auth_headers, mock_invalidate_token, mock_auth_headers
+    ):
+        mock_get_auth_headers.side_effect = [
+            {"authorization": "Bearer stale-token"},
+            {"authorization": "Bearer fresh-token"},
+        ]
+
+        invalid_response = MagicMock()
+        invalid_response.content = b'{"code":40003,"msg":"Authorization Failed (invalid token)","data":null}'
+        invalid_response.status_code = 200
+        invalid_response.headers = {}
+
+        success_response = MagicMock()
+        success_response.content = b'{"code":0,"data":{"biz_data":{"id":"session-123"}}}'
+        success_response.status_code = 200
+        success_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=[invalid_response, success_response])
+        mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_class.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await v0_service.proxy_to_deepseek("POST", "api/v0/test", json_data={"test": True})
+
+        assert result.status_code == 200
+        assert mock_client.request.await_count == 2
+        mock_invalidate_token.assert_called_once()
+
 
 class TestCreateSession:
     """Test create_session function."""
@@ -148,6 +181,39 @@ class TestCreateSession:
 
         assert session_id is None
 
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek")
+    async def test_create_session_handles_unexpected_backend_payload(self, mock_proxy, reset_parent_msg_store):
+        mock_response = MagicMock()
+        mock_response.body = json.dumps({
+            "code": 40003,
+            "msg": "auth failed",
+            "data": None,
+        }).encode()
+        mock_response.status_code = 200
+        mock_proxy.return_value = mock_response
+
+        session_id, resp = await v0_service.create_session()
+
+        assert session_id is None
+        assert resp is mock_response
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek")
+    async def test_create_session_recovers_after_invalid_token_retry(self, mock_proxy, reset_parent_msg_store):
+        mock_response = MagicMock()
+        mock_response.body = json.dumps({
+            "code": 0,
+            "data": {"biz_data": {"id": "session-789"}}
+        }).encode()
+        mock_response.status_code = 200
+        mock_proxy.return_value = mock_response
+
+        session_id, resp = await v0_service.create_session()
+
+        assert session_id == "session-789"
+        assert resp.status_code == 200
+
 
 class TestDeleteSession:
     """Test delete_session function."""
@@ -169,10 +235,11 @@ class TestDeleteSession:
         mock_response.status_code = 200
         mock_proxy.return_value = mock_response
 
-        await v0_service.delete_session("session-to-delete")
+        result = await v0_service.delete_session("session-to-delete")
 
         # Verify session was removed from store
         assert await store.ahas("session-to-delete") is False
+        assert result is mock_response
 
     @pytest.mark.asyncio
     @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek")
@@ -186,10 +253,12 @@ class TestDeleteSession:
         # Simulate backend failure
         mock_proxy.side_effect = Exception("Network error")
 
-        await v0_service.delete_session("session-fail")
+        result = await v0_service.delete_session("session-fail")
 
         # Verify session was still removed from store
         assert await store.ahas("session-fail") is False
+        assert result.status_code == 502
+        assert b"Failed to delete session after retries" in result.body
 
     @pytest.mark.asyncio
     @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek")
@@ -210,9 +279,25 @@ class TestDeleteSession:
 
         mock_proxy.side_effect = [fail_response, success_response]
 
-        await v0_service.delete_session("session-retry")
+        result = await v0_service.delete_session("session-retry")
 
         assert mock_proxy.call_count == 2
+        assert result is success_response
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek")
+    async def test_delete_session_returns_last_backend_response_on_biz_failure(self, mock_proxy, reset_parent_msg_store):
+        fail_response = MagicMock()
+        fail_response.body = json.dumps({
+            "data": {"biz_code": 1, "biz_msg": "still failing"}
+        }).encode()
+        fail_response.status_code = 200
+
+        mock_proxy.return_value = fail_response
+
+        result = await v0_service.delete_session("session-fail")
+
+        assert result is fail_response
 
 
 class TestStreamChatCompletion:
@@ -277,9 +362,11 @@ class TestStreamChatCompletion:
 
     @pytest.mark.asyncio
     @patch("deepseek_web_api.api.v0_service.get_pow_response")
-    async def test_stream_fails_without_pow(self, mock_get_pow, reset_parent_msg_store):
+    @patch("deepseek_web_api.api.v0_service.create_session")
+    async def test_stream_fails_without_pow(self, mock_create_session, mock_get_pow, reset_parent_msg_store):
         """Test that stream yields error when PoW fails."""
         mock_get_pow.return_value = None
+        mock_create_session.return_value = ("session-no-pow", MagicMock())
 
         chunks = []
         async for chunk in v0_service.stream_chat_completion("Hello"):

--- a/tests/core/test_server_security.py
+++ b/tests/core/test_server_security.py
@@ -1,0 +1,45 @@
+"""Tests for startup security warnings."""
+
+import sys
+
+sys.path.insert(0, "src")
+
+from deepseek_web_api.core import server_security
+
+
+class TestServerSecurity:
+    def test_is_loopback_host(self):
+        assert server_security.is_loopback_host("127.0.0.1") is True
+        assert server_security.is_loopback_host("localhost") is True
+        assert server_security.is_loopback_host("[::1]") is True
+        assert server_security.is_loopback_host("0.0.0.0") is False
+
+    def test_collect_startup_security_warnings_for_open_defaults(self, monkeypatch):
+        monkeypatch.setattr(server_security, "get_server_host", lambda: "127.0.0.1")
+        monkeypatch.setattr(server_security, "get_local_api_key", lambda: "")
+        monkeypatch.setattr(server_security, "get_cors_origins", lambda: ["*"])
+
+        warnings = server_security.collect_startup_security_warnings()
+
+        assert any("Local API auth is disabled" in warning for warning in warnings)
+        assert any("CORS allows all origins" in warning for warning in warnings)
+        assert not any("not loopback" in warning for warning in warnings)
+
+    def test_collect_startup_security_warnings_for_remote_exposure(self, monkeypatch):
+        monkeypatch.setattr(server_security, "get_server_host", lambda: "0.0.0.0")
+        monkeypatch.setattr(server_security, "get_local_api_key", lambda: "")
+        monkeypatch.setattr(server_security, "get_cors_origins", lambda: ["https://app.example.com"])
+
+        warnings = server_security.collect_startup_security_warnings()
+
+        assert any("not loopback" in warning for warning in warnings)
+        assert any("unsafe" in warning for warning in warnings)
+
+    def test_collect_startup_security_warnings_for_hardened_config(self, monkeypatch):
+        monkeypatch.setattr(server_security, "get_server_host", lambda: "127.0.0.1")
+        monkeypatch.setattr(server_security, "get_local_api_key", lambda: "secret-token")
+        monkeypatch.setattr(server_security, "get_cors_origins", lambda: ["https://app.example.com"])
+
+        warnings = server_security.collect_startup_security_warnings()
+
+        assert warnings == []


### PR DESCRIPTION
# PR：强化代理协议正确性与本地服务安全性

## 摘要

这个 PR 主要完成了两类工作：

- 修复 DeepSeek 代理层中若干协议正确性问题
- 对本地服务暴露面做第一轮安全加固

本次改动的目标是：

- 让 `/v1/chat/completions` 在流式响应和工具调用场景下表现得更符合预期
- 保留后端删除接口的真实返回结果，并补全远端 session 清理
- 为 `/v0/*` 和 `/v1/*` 增加可选的本地 API 鉴权
- 将服务监听参数与 CORS 行为从硬编码改为可配置

## 变更内容

### 1. 修复 v1 协议正确性问题

- 让 `/v1/chat/completions` 正确尊重 `search_enabled`
- 修复非流式路径中空 chunk 缓冲区导致的 `raise None`，改为返回 `502`
- 修复工具调用流式路径上重复发送 `data: [DONE]` 的问题
- 将 SSE 解析从“按单次网络 chunk 切分”改为“带缓冲的事件帧提取”，正确处理跨 chunk 分片

### 2. 修复 session 生命周期处理

- 让 `/v0/chat/delete` 返回最后一次后端响应，而不是吞掉返回值
- 当删除重试全部失败且从未拿到后端响应时，返回本地构造的 `502` JSON
- 让 stateless session pool 的 idle cleanup 不仅清理本地字典，也尝试删除 DeepSeek 远端 session

### 3. 增加本地 API 鉴权

- 新增可选的本地 API 鉴权模块
- 当配置 `[server].api_key` 或环境变量 `DEEPSEEK_WEB_API_KEY` 时，请求必须携带以下任一方式：
  - `Authorization: Bearer <token>`
  - `X-API-Key: <token>`
- 当未配置本地 API key 时，默认行为保持兼容
- `/` 健康检查接口保持开放

### 4. 显式化服务端配置

- 将 host / port / reload 的读取集中到配置辅助函数中
- 让 `main.py` 读取 `[server].host`、`[server].port`、`[server].reload`
- 让 CORS 通过 `[server].cors_*` 配置
- 新增启动期安全告警，在以下风险组合下给出明确 warning：
  - 未启用本地鉴权
  - 使用通配符 CORS
  - 监听非 loopback 地址

### 5. 同步文档与依赖说明

- 更新 `config.toml.example`
- 更新中英文 README
- 将 `tomli-w>=1.2.0` 加入 `requirements.txt`，与当前运行时行为保持一致

## 测试

本次新增或扩展了以下测试覆盖：

- SSE 跨 chunk 事件缓冲
- tool call 流只发送一次 `[DONE]`
- `/v1` 路由对 `search_enabled` 的处理
- 非流式空 chunk 的错误处理
- session pool idle eviction 时的远端清理
- `/v0/chat/delete` 返回语义
- 本地 API 鉴权中间件
- CORS 配置映射
- 启动期安全告警生成逻辑

## 验证方式

在项目 `.venv` 中执行：

```powershell
.\.venv\Scripts\python.exe -m pytest tests/api tests/core -q
```

结果：

- `132 passed`

## 兼容性说明

- 为了兼容旧用法，本地 API 鉴权默认仍然关闭
- 为了兼容旧行为，CORS 默认仍然较宽松，但现在已可配置，且会在启动时发出风险告警
- 本 PR 不包含多模态输入支持

