### PR TITLE
fix: 强制限制 session pool 硬上限并为流式限流增加退避重试

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ cors_origins = ["*"]                 # Recommended: replace with explicit origin
 cors_allow_credentials = false
 cors_allow_methods = ["*"]
 cors_allow_headers = ["*"]
+pool_size = 10                       # Max concurrent DeepSeek sessions (env: DEEPSEEK_WEB_POOL_SIZE)
+pool_acquire_timeout = 30.0          # Seconds to wait for a free session before returning 503 (env: DEEPSEEK_WEB_POOL_ACQUIRE_TIMEOUT)
 
 [auth]
 tokens = []                          # Configure one or more tokens to enable auth
@@ -192,6 +194,19 @@ Implements stateless sessions via `edit_message` API:
 - Model always thinks it's the "first conversation", avoiding session state accumulation
 - Supports `deepseek-web-reasoner` model's thinking content
 
+**Session Pool**:
+- Maintains a bounded pool of DeepSeek sessions (`pool_size`, default 10)
+- When all sessions are busy, new requests wait up to `pool_acquire_timeout` seconds (default 30s) before returning HTTP 503
+- Idle sessions are cleaned up automatically every `max_idle_seconds/2` (default 150s)
+- Hard cap prevents flooding DeepSeek with unbounded concurrent session creations
+
+**Rate Limit Handling**:
+- `proxy_to_deepseek_stream` detects HTTP 429 and 5xx responses before yielding any bytes
+- On rate limit, retries up to 3 times with exponential backoff (5s, 10s, 20s), respecting `Retry-After` header
+- Each retry fetches a fresh PoW challenge (challenges expire)
+- If all retries fail: streaming returns an SSE error chunk; non-streaming returns HTTP 503
+- Rate limit errors do NOT trigger session pool retry (account-wide limit, switching sessions won't help)
+
 **Anti-Hallucination Mechanism**:
 When the model outputs `[TOOL🛠️]...[/TOOL🛠️]`:
 1. The adapter extracts and parses the tool call JSON
@@ -204,6 +219,8 @@ When the model outputs `[TOOL🛠️]...[/TOOL🛠️]`:
 - [x] Simple wrapper for deepseek_web_chat API
 - [x] Implement openai_chat_completions protocol adapter
 - [x] Streaming tool call extraction for openai adapter
+- [x] Session pool hard cap to prevent flooding DeepSeek with concurrent session creations
+- [x] Rate limit detection (HTTP 429/5xx) with exponential backoff retry in streaming path
 - [ ] Implement claude_message protocol adapter via [litellm](https://github.com/BerriAI/litellm) (convert OpenAI protocol to Claude protocol)
 - [ ] Implement multi-user account load balancing to prevent DeepSeek rate limiting with concurrent requests
 

--- a/README.中文.md
+++ b/README.中文.md
@@ -41,6 +41,8 @@ cors_origins = ["*"]                 # 建议改成明确白名单
 cors_allow_credentials = false
 cors_allow_methods = ["*"]
 cors_allow_headers = ["*"]
+pool_size = 10                       # 最大并发 DeepSeek session 数（环境变量: DEEPSEEK_WEB_POOL_SIZE）
+pool_acquire_timeout = 30.0          # 等待可用 session 的超时秒数，超时返回 503（环境变量: DEEPSEEK_WEB_POOL_ACQUIRE_TIMEOUT）
 
 [auth]
 tokens = []                          # 配置一个或多个 token 启用鉴权
@@ -189,6 +191,19 @@ response = client.chat.completions.create(
 - 模型始终认为这是"第一次对话"，避免会话状态累积
 - 支持 `deepseek-web-reasoner` 模型的思考内容
 
+**Session Pool**：
+- 维护有上限的 DeepSeek session 池（`pool_size`，默认 10）
+- 当所有 session 繁忙时，新请求最多等待 `pool_acquire_timeout` 秒（默认 30s），超时返回 HTTP 503
+- 空闲 session 每 `max_idle_seconds/2`（默认 150s）自动清理
+- 硬上限防止并发请求时无限制地创建 session 触发限流
+
+**限流处理**：
+- `proxy_to_deepseek_stream` 在 yield 任何字节前检测 HTTP 429 和 5xx 响应
+- 遇到限流时最多重试 3 次，指数退避（5s、10s、20s），并遵守 `Retry-After` header
+- 每次重试独立获取新 PoW（旧 PoW 会过期）
+- 全部重试失败后：流式返回 SSE 错误 chunk；非流式返回 HTTP 503
+- 限流错误不会触发 session pool 重试（账号级限流，换 session 无效）
+
 **防幻觉机制**：
 当模型输出 `[TOOL🛠️]...[/TOOL🛠️]` 时：
 1. 适配器提取并解析工具调用 JSON
@@ -201,6 +216,8 @@ response = client.chat.completions.create(
 - [x] 简单包装 deepseek_web_chat API
 - [x] 实现 openai_chat_completions 协议适配器
 - [x] openai适配器的流式工具调用提取
+- [x] Session pool 硬上限，防止并发 session 创建触发限流
+- [x] 流式路径限流检测（HTTP 429/5xx）与指数退避重试
 - [ ] 通过 [litellm](https://github.com/BerriAI/litellm) 实现 claude_message 协议适配器（转换OpenAI协议到Claude协议）
 - [ ] 实现多用户账户负载均衡，防止 DeepSeek 请求频率限制
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,8 @@ cors_origins = ["*"]  # 生产环境建议改成明确白名单
 cors_allow_credentials = false
 cors_allow_methods = ["*"]
 cors_allow_headers = ["*"]
+pool_size = 10              # 最大并发 DeepSeek session 数；超出时请求等待（环境变量: DEEPSEEK_WEB_POOL_SIZE）
+pool_acquire_timeout = 30.0 # 等待可用 session 的超时秒数，超时返回 503（环境变量: DEEPSEEK_WEB_POOL_ACQUIRE_TIMEOUT）
 
 [auth]
 # 鉴权 token 列表；非空列表表示需要鉴权，空列表仅在 loopback 时允许

--- a/docs/CORE.md
+++ b/docs/CORE.md
@@ -44,7 +44,9 @@ impersonate = "safari15_3"
 | `BASE_HEADERS` | 从配置读取的 HTTP 请求头 |
 | `DEFAULT_IMPERSONATE` | 浏览器伪装标识 |
 | `WASM_PATH` | WASM 模块文件路径 |
-| `get_auth_tokens()` | 读取 `auth.tokens` 字符串数组 |
+| `get_auth_tokens()` | 读取 `auth.tokens` 字符串数组（非空则需要鉴权） |
+| `get_pool_size()` | 读取 session pool 最大并发数（默认 10，环境变量 `DEEPSEEK_WEB_POOL_SIZE`） |
+| `get_pool_acquire_timeout()` | 读取等待 session 的超时秒数（默认 30.0，环境变量 `DEEPSEEK_WEB_POOL_ACQUIRE_TIMEOUT`） |
 | `get_server_host()` | 读取 `[server].host` |
 | `get_server_port()` | 读取 `[server].port` |
 | `get_server_reload()` | 读取 `[server].reload` |

--- a/src/deepseek_web_api/api/openai/chat_completions/route.py
+++ b/src/deepseek_web_api/api/openai/chat_completions/route.py
@@ -13,7 +13,8 @@ from pydantic import BaseModel
 from ....core.logger import logger
 from .messages import convert_messages_to_prompt
 from .service import stream_generator
-from .session_pool import get_pool
+from .session_pool import get_pool, SessionPoolFullError
+from ....api.v0_service import RateLimitError
 
 
 router = APIRouter()
@@ -91,6 +92,13 @@ async def chat_completions(request: Request):
             for session_retry in range(_MAX_SESSION_RETRIES):
                 try:
                     session = await pool.acquire()
+                except SessionPoolFullError as e:
+                    logger.warning(f"[stream] pool exhausted: {e}")
+                    async for chunk in _emit_stream_error(
+                        "Service temporarily unavailable: all DeepSeek sessions are busy, please retry later"
+                    ):
+                        yield chunk
+                    return
                 except Exception as e:
                     logger.error(f"[stream] failed to acquire session: {e}")
                     async for chunk in _emit_stream_error(
@@ -131,6 +139,17 @@ async def chat_completions(request: Request):
                         for b in buffered:
                             yield b
                         buffered.clear()
+                except RateLimitError as e:
+                    # Rate limit is account/IP-wide — retrying with a different session won't help.
+                    # The inner retry loop (in stream_chat_completion/stream_edit_message) already
+                    # exhausted its attempts; surface the error without touching session state.
+                    logger.warning(f"[stream] DeepSeek rate limit exhausted all retries: {e}")
+                    if not started_yielding:
+                        async for chunk in _emit_stream_error(
+                            "DeepSeek rate limit exceeded, please retry later"
+                        ):
+                            yield chunk
+                    return  # No session retry — a different session won't help
                 except Exception as e:
                     error_session = True
                     logger.warning(f"[stream] session {session.chat_session_id[:8]}... error: {e}")
@@ -170,6 +189,12 @@ async def chat_completions(request: Request):
     for session_retry in range(_MAX_SESSION_RETRIES):
         try:
             session = await pool.acquire()
+        except SessionPoolFullError as e:
+            logger.warning(f"[non-stream] pool exhausted: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Service temporarily unavailable: all DeepSeek sessions are busy, please retry later",
+            )
         except Exception as e:
             last_exc = e
             logger.error(f"[non-stream] failed to acquire session: {e}")
@@ -186,6 +211,10 @@ async def chat_completions(request: Request):
             ):
                 chunks.append(chunk)
             break  # Success
+        except RateLimitError as e:
+            last_exc = e
+            logger.warning(f"[non-stream] DeepSeek rate limit exhausted all retries: {e}")
+            # Don't retry with a different session — rate limit is account/IP-wide
         except Exception as e:
             error_session = True
             last_exc = e
@@ -201,6 +230,11 @@ async def chat_completions(request: Request):
 
     # If all retries failed, raise the last exception
     if not chunks:
+        if isinstance(last_exc, (RateLimitError, SessionPoolFullError)):
+            raise HTTPException(
+                status_code=503,
+                detail="Service temporarily unavailable: DeepSeek rate limit exceeded, please retry later",
+            )
         if last_exc is not None:
             raise last_exc
         raise HTTPException(status_code=502, detail="DeepSeek returned no completion chunks")

--- a/src/deepseek_web_api/api/openai/chat_completions/session_pool.py
+++ b/src/deepseek_web_api/api/openai/chat_completions/session_pool.py
@@ -7,6 +7,7 @@ Architecture:
 - Each session in the pool maintains message_id=1
 - The pool is "stateless" from the client's perspective (no session_id needed)
 - Internally, we track which sessions are initialized (have message_id=1 created)
+- Pool size is hard-capped; callers block until a session is available or timeout
 """
 
 import asyncio
@@ -46,6 +47,12 @@ class AllSessionsBusyError(SessionPoolError):
     pass
 
 
+class SessionPoolFullError(SessionPoolError):
+    """Raised when the pool is at capacity and no session becomes available within the timeout."""
+
+    pass
+
+
 class StatelessSessionPool:
     """Pool of sessions for stateless chat completions.
 
@@ -54,6 +61,8 @@ class StatelessSessionPool:
     to minimize session creation overhead.
 
     The pool provides:
+    - Hard cap on concurrent sessions (pool_size) to avoid triggering DeepSeek rate limits
+    - Callers block in acquire() until a session is available or acquire_timeout expires
     - Per-session locking to prevent concurrent use
     - Lazy initialization (first request uses completion, subsequent use edit_message)
     - Automatic cleanup of idle sessions
@@ -64,49 +73,104 @@ class StatelessSessionPool:
         self,
         max_idle_seconds: float = 300,
         pool_size: int = 10,
+        acquire_timeout: float = 30.0,
     ):
         """Initialize the session pool.
 
         Args:
             max_idle_seconds: Sessions idle longer than this are eligible for cleanup
-            pool_size: Target number of sessions to keep in the pool
+            pool_size: Hard cap on concurrent sessions; callers wait when this is reached
+            acquire_timeout: Seconds to wait for an available session before raising
         """
         self._sessions: dict[str, StatelessSession] = {}
-        self._lock = asyncio.Lock()
+        self._condition = asyncio.Condition()
+        self._pending_creates: int = 0  # Sessions being created (reserved slots)
         self._max_idle_seconds = max_idle_seconds
         self._pool_size = pool_size
+        self._acquire_timeout = acquire_timeout
         self._cleanup_task: Optional[asyncio.Task] = None
-        logger.info(f"[StatelessSessionPool] initialized with pool_size={pool_size}, max_idle={max_idle_seconds}s")
+        logger.info(
+            f"[StatelessSessionPool] initialized with pool_size={pool_size}, "
+            f"max_idle={max_idle_seconds}s, acquire_timeout={acquire_timeout}s"
+        )
 
     async def acquire(self) -> StatelessSession:
         """Acquire an available session from the pool.
 
-        Returns the first available (unlocked) session. If all sessions are busy,
-        creates a new session.
+        Returns the first available (unlocked) session. If the pool is below
+        capacity, creates a new session. If the pool is at capacity and all
+        sessions are busy, blocks until one is released or the timeout expires.
 
         Returns:
             StatelessSession: An available session (already locked)
 
         Raises:
-            AllSessionsBusyError: If unable to acquire any session (should not happen
-                                 as we create new sessions as fallback)
+            SessionPoolFullError: If no session becomes available within acquire_timeout
+            SessionPoolError: If session creation fails
         """
-        # Fast path: try to find an unlocked session
-        async with self._lock:
-            for session in self._sessions.values():
-                if not session.lock.locked():
-                    # Found an available session
-                    await session.lock.acquire()
-                    session.last_access_time = time.time()
-                    logger.debug(f"[pool] acquired session {session.chat_session_id[:8]}..., locked={session.lock.locked()}")
-                    return session
+        deadline = asyncio.get_event_loop().time() + self._acquire_timeout
 
-            # All sessions are busy or pool is empty - create new session
-            new_session = await self._create_session()
-            self._sessions[new_session.chat_session_id] = new_session
-            await new_session.lock.acquire()
-            logger.info(f"[pool] created new session {new_session.chat_session_id[:8]}..., pool size={len(self._sessions)}")
-            return new_session
+        while True:
+            # Phase 1: Check pool state under condition lock
+            async with self._condition:
+                # Try to find an available unlocked session
+                for session in self._sessions.values():
+                    if not session.lock.locked():
+                        await session.lock.acquire()
+                        session.last_access_time = time.time()
+                        logger.debug(f"[pool] acquired existing session {session.chat_session_id[:8]}...")
+                        return session
+
+                # Can we grow the pool? (count pending creates as reserved slots)
+                effective_size = len(self._sessions) + self._pending_creates
+                if effective_size < self._pool_size:
+                    # Reserve a slot; will create outside the lock below
+                    self._pending_creates += 1
+                    logger.info(
+                        f"[pool] growing pool: {len(self._sessions)} sessions + "
+                        f"{self._pending_creates} pending = {effective_size + 1}/{self._pool_size}"
+                    )
+                    # Fall through to Phase 2 after exiting this block
+                else:
+                    # Pool at capacity, all sessions busy — wait for a release notification
+                    remaining = deadline - asyncio.get_event_loop().time()
+                    if remaining <= 0:
+                        raise SessionPoolFullError(
+                            f"Pool exhausted: all {self._pool_size} sessions busy, "
+                            f"timed out after {self._acquire_timeout:.1f}s"
+                        )
+                    logger.info(
+                        f"[pool] all {self._pool_size} sessions busy, "
+                        f"waiting up to {remaining:.1f}s for one to free up..."
+                    )
+                    try:
+                        await asyncio.wait_for(self._condition.wait(), timeout=remaining)
+                    except asyncio.TimeoutError:
+                        raise SessionPoolFullError(
+                            f"Pool exhausted: all {self._pool_size} sessions busy, "
+                            f"timed out after {self._acquire_timeout:.1f}s"
+                        )
+                    continue  # Woken by notify_all() — re-check at top of loop
+
+            # Phase 2: Create new session outside lock (avoids blocking other acquires during HTTP call)
+            try:
+                new_session = await self._create_session()
+            except Exception as e:
+                async with self._condition:
+                    self._pending_creates -= 1
+                    self._condition.notify_all()  # Free the reserved slot for waiters
+                raise SessionPoolError(f"Failed to create DeepSeek session: {e}") from e
+
+            # Phase 3: Register in pool and lock it
+            async with self._condition:
+                self._pending_creates -= 1
+                self._sessions[new_session.chat_session_id] = new_session
+                await new_session.lock.acquire()
+                logger.info(
+                    f"[pool] created session {new_session.chat_session_id[:8]}..., "
+                    f"pool size={len(self._sessions)}"
+                )
+                return new_session
 
     async def release(self, session: StatelessSession, error: bool = False) -> None:
         """Release a session back to the pool.
@@ -121,7 +185,11 @@ class StatelessSessionPool:
             logger.warning(f"[pool] session {session.chat_session_id[:8]}... marked for re-init due to error")
 
         session.last_access_time = time.time()
-        session.lock.release()
+
+        async with self._condition:
+            session.lock.release()
+            self._condition.notify_all()  # Wake any callers waiting in acquire()
+
         logger.debug(f"[pool] released session {session.chat_session_id[:8]}..., error={error}")
 
     async def cleanup_idle(self) -> int:
@@ -133,7 +201,7 @@ class StatelessSessionPool:
         now = time.time()
         removed = 0
 
-        async with self._lock:
+        async with self._condition:
             to_remove = [
                 sid
                 for sid, session in self._sessions.items()
@@ -240,7 +308,11 @@ async def get_pool() -> StatelessSessionPool:
     if _pool is None:
         async with _pool_lock:
             if _pool is None:
-                _pool = StatelessSessionPool()
+                from ....core.config import get_pool_size, get_pool_acquire_timeout
+                _pool = StatelessSessionPool(
+                    pool_size=get_pool_size(),
+                    acquire_timeout=get_pool_acquire_timeout(),
+                )
                 _pool.start_cleanup()
     return _pool
 

--- a/src/deepseek_web_api/api/v0_service.py
+++ b/src/deepseek_web_api/api/v0_service.py
@@ -27,6 +27,27 @@ _PATH_HISTORY_MESSAGES = "api/v0/chat/history_messages"
 
 DEEPSEEK_BASE_URL = f"https://{DEEPSEEK_HOST}"
 
+_MAX_RATE_LIMIT_RETRIES = 3
+_RATE_LIMIT_BASE_DELAY = 5.0  # seconds; doubles each retry
+
+
+class RateLimitError(Exception):
+    """Raised when DeepSeek returns a rate-limit response (HTTP 429/5xx) before any bytes are yielded."""
+
+    def __init__(self, message: str, retry_after: float = 0.0):
+        super().__init__(message)
+        self.retry_after = retry_after  # Seconds to wait, from Retry-After header if present
+
+
+def _parse_retry_after(value: str | None) -> float:
+    """Parse Retry-After header value into seconds. Returns 0.0 if absent or unparseable."""
+    if not value:
+        return 0.0
+    try:
+        return max(0.0, float(value))
+    except (ValueError, TypeError):
+        return 0.0
+
 
 def _response_indicates_invalid_token(content: bytes) -> bool:
     """Return True if DeepSeek response payload indicates token invalidation."""
@@ -108,7 +129,11 @@ async def proxy_to_deepseek_stream(
     json_data: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
 ) -> AsyncGenerator[bytes, None]:
-    """Proxy request to DeepSeek backend as a streaming response, yield bytes."""
+    """Proxy request to DeepSeek backend as a streaming response, yield bytes.
+
+    Raises:
+        RateLimitError: If DeepSeek responds with HTTP 429 or 5xx before any bytes are yielded.
+    """
     url = f"{DEEPSEEK_BASE_URL}/{path}"
     logger.debug(f"[proxy:stream] {method} {path}")
     auth_headers = get_auth_headers()
@@ -126,6 +151,19 @@ async def proxy_to_deepseek_stream(
             json=json_data,
             params=params,
         ) as resp:
+            if resp.status_code == 429:
+                body = await resp.aread()
+                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                raise RateLimitError(
+                    f"DeepSeek rate limited (HTTP 429): {body[:200]!r}",
+                    retry_after=retry_after,
+                )
+            if resp.status_code >= 500:
+                body = await resp.aread()
+                raise RateLimitError(
+                    f"DeepSeek server error (HTTP {resp.status_code}): {body[:200]!r}",
+                    retry_after=5.0,
+                )
             async for chunk in resp.aiter_bytes():
                 yield chunk
 
@@ -363,45 +401,66 @@ async def stream_chat_completion(
             return
         parent_message_id = None
 
-    # Get PoW
-    pow_response = get_pow_response()
-    if not pow_response:
-        logger.error("[stream_chat_completion] Failed to get PoW response")
-        yield b"data: {\"error\": \"Failed to get PoW response\"}\n\n"
-        yield b"event: finish\ndata: {}\n\n"
-        return
+    # Get PoW and stream, with retry on rate limit
+    last_rate_limit_error: RateLimitError | None = None
+    for rate_limit_attempt in range(_MAX_RATE_LIMIT_RETRIES):
+        if rate_limit_attempt > 0:
+            delay = max(
+                _RATE_LIMIT_BASE_DELAY * (2 ** (rate_limit_attempt - 1)),
+                last_rate_limit_error.retry_after if last_rate_limit_error else 0.0,
+            )
+            logger.warning(
+                f"[stream_chat] rate limited by DeepSeek, "
+                f"retrying in {delay:.1f}s (attempt {rate_limit_attempt + 1}/{_MAX_RATE_LIMIT_RETRIES})"
+            )
+            await asyncio.sleep(delay)
 
-    # Build payload for DeepSeek
-    payload = {
-        "chat_session_id": chat_session_id,
-        "parent_message_id": parent_message_id,
-        "preempt": False,
-        "prompt": prompt,
-        "ref_file_ids": ref_file_ids or [],
-        "search_enabled": search_enabled,
-        "thinking_enabled": thinking_enabled,
-    }
+        # Fresh PoW each attempt (challenges expire)
+        pow_response = get_pow_response()
+        if not pow_response:
+            logger.error("[stream_chat_completion] Failed to get PoW response")
+            yield b"data: {\"error\": \"Failed to get PoW response\"}\n\n"
+            yield b"event: finish\ndata: {}\n\n"
+            return
 
-    headers = {"x-ds-pow-response": pow_response}
+        # Build payload for DeepSeek
+        payload = {
+            "chat_session_id": chat_session_id,
+            "parent_message_id": parent_message_id,
+            "preempt": False,
+            "prompt": prompt,
+            "ref_file_ids": ref_file_ids or [],
+            "search_enabled": search_enabled,
+            "thinking_enabled": thinking_enabled,
+        }
+        headers = {"x-ds-pow-response": pow_response}
 
-    # Stream and collect only if we need to extract message_id
-    collected = b"" if chat_session_id else None
-    async for chunk in proxy_to_deepseek_stream(
-        "POST",
-        _PATH_COMPLETION,
-        headers=headers,
-        json_data=payload,
-    ):
-        if collected is not None:
-            collected += chunk
-        yield chunk
+        try:
+            # Stream and collect only if we need to extract message_id
+            collected = b"" if chat_session_id else None
+            async for chunk in proxy_to_deepseek_stream(
+                "POST",
+                _PATH_COMPLETION,
+                headers=headers,
+                json_data=payload,
+            ):
+                if collected is not None:
+                    collected += chunk
+                yield chunk
 
-    # Update session with message_id after stream completes
-    if collected is not None:
-        msg_id = parse_sse_response_message_id(collected)
-        if msg_id:
-            await ParentMsgStore.get_instance().aupdate_parent_message_id(chat_session_id, msg_id)
-            logger.info(f"[stream_chat] session={chat_session_id} updated parent_msg_id={msg_id}")
+            # Update session with message_id after stream completes
+            if collected is not None:
+                msg_id = parse_sse_response_message_id(collected)
+                if msg_id:
+                    await ParentMsgStore.get_instance().aupdate_parent_message_id(chat_session_id, msg_id)
+                    logger.info(f"[stream_chat] session={chat_session_id} updated parent_msg_id={msg_id}")
+            return  # Success
+
+        except RateLimitError as e:
+            last_rate_limit_error = e
+            if rate_limit_attempt == _MAX_RATE_LIMIT_RETRIES - 1:
+                logger.error(f"[stream_chat] all rate-limit retries exhausted: {e}")
+                raise
 
 
 async def stream_edit_message(
@@ -435,38 +494,59 @@ async def stream_edit_message(
             yield b"event: finish\ndata: {}\n\n"
             return
 
-    # Get PoW
-    pow_response = get_pow_response()
-    if not pow_response:
-        logger.error("[edit_message] Failed to get PoW response")
-        yield b"data: {\"error\": \"Failed to get PoW response\"}\n\n"
-        yield b"event: finish\ndata: {}\n\n"
-        return
+    # Get PoW and stream, with retry on rate limit
+    last_rate_limit_error: RateLimitError | None = None
+    for rate_limit_attempt in range(_MAX_RATE_LIMIT_RETRIES):
+        if rate_limit_attempt > 0:
+            delay = max(
+                _RATE_LIMIT_BASE_DELAY * (2 ** (rate_limit_attempt - 1)),
+                last_rate_limit_error.retry_after if last_rate_limit_error else 0.0,
+            )
+            logger.warning(
+                f"[edit_message] rate limited by DeepSeek, "
+                f"retrying in {delay:.1f}s (attempt {rate_limit_attempt + 1}/{_MAX_RATE_LIMIT_RETRIES})"
+            )
+            await asyncio.sleep(delay)
 
-    # Build payload with fixed message_id=1
-    payload = {
-        "chat_session_id": chat_session_id,
-        "message_id": 1,  # Fixed message_id for stateless conversation
-        "prompt": prompt,
-        "search_enabled": search_enabled,
-        "thinking_enabled": thinking_enabled,
-    }
+        # Fresh PoW each attempt (challenges expire)
+        pow_response = get_pow_response()
+        if not pow_response:
+            logger.error("[edit_message] Failed to get PoW response")
+            yield b"data: {\"error\": \"Failed to get PoW response\"}\n\n"
+            yield b"event: finish\ndata: {}\n\n"
+            return
 
-    headers = {"x-ds-pow-response": pow_response}
+        # Build payload with fixed message_id=1
+        payload = {
+            "chat_session_id": chat_session_id,
+            "message_id": 1,  # Fixed message_id for stateless conversation
+            "prompt": prompt,
+            "search_enabled": search_enabled,
+            "thinking_enabled": thinking_enabled,
+        }
+        headers = {"x-ds-pow-response": pow_response}
 
-    # Stream from DeepSeek
-    collected = b""
-    async for chunk in proxy_to_deepseek_stream(
-        "POST",
-        _PATH_EDIT_MESSAGE,
-        headers=headers,
-        json_data=payload,
-    ):
-        collected += chunk
-        yield chunk
+        try:
+            # Stream from DeepSeek
+            collected = b""
+            async for chunk in proxy_to_deepseek_stream(
+                "POST",
+                _PATH_EDIT_MESSAGE,
+                headers=headers,
+                json_data=payload,
+            ):
+                collected += chunk
+                yield chunk
 
-    # Update parent_message_id for future calls
-    msg_id = parse_sse_response_message_id(collected)
-    if msg_id:
-        await ParentMsgStore.get_instance().aupdate_parent_message_id(chat_session_id, msg_id)
-        logger.info(f"[edit_message] session={chat_session_id} updated parent_msg_id={msg_id}")
+            # Update parent_message_id for future calls
+            msg_id = parse_sse_response_message_id(collected)
+            if msg_id:
+                await ParentMsgStore.get_instance().aupdate_parent_message_id(chat_session_id, msg_id)
+                logger.info(f"[edit_message] session={chat_session_id} updated parent_msg_id={msg_id}")
+            return  # Success
+
+        except RateLimitError as e:
+            last_rate_limit_error = e
+            if rate_limit_attempt == _MAX_RATE_LIMIT_RETRIES - 1:
+                logger.error(f"[edit_message] all rate-limit retries exhausted: {e}")
+                raise

--- a/src/deepseek_web_api/core/config.py
+++ b/src/deepseek_web_api/core/config.py
@@ -117,6 +117,22 @@ def get_auth_tokens() -> list[str]:
     return [str(t).strip() for t in tokens if str(t).strip()]
 
 
+def get_pool_size() -> int:
+    """Max concurrent DeepSeek sessions in the stateless session pool."""
+    env_val = os.getenv("DEEPSEEK_WEB_POOL_SIZE")
+    if env_val is not None:
+        return int(env_val)
+    return int(_get_server_config().get("pool_size", 10))
+
+
+def get_pool_acquire_timeout() -> float:
+    """Seconds to wait for an available session before returning 503."""
+    env_val = os.getenv("DEEPSEEK_WEB_POOL_ACQUIRE_TIMEOUT")
+    if env_val is not None:
+        return float(env_val)
+    return float(_get_server_config().get("pool_acquire_timeout", 30.0))
+
+
 def get_server_host() -> str:
     return str(_get_server_config().get("host", "127.0.0.1")).strip()
 

--- a/tests/api/test_chat_completions/test_session_pool.py
+++ b/tests/api/test_chat_completions/test_session_pool.py
@@ -11,6 +11,7 @@ from deepseek_web_api.api.openai.chat_completions.session_pool import (
     StatelessSession,
     StatelessSessionPool,
     SessionPoolError,
+    SessionPoolFullError,
     get_pool,
 )
 
@@ -38,7 +39,7 @@ class TestStatelessSessionPool:
 
     @pytest.fixture
     def pool(self):
-        return StatelessSessionPool(max_idle_seconds=60, pool_size=5)
+        return StatelessSessionPool(max_idle_seconds=60, pool_size=5, acquire_timeout=2.0)
 
     @pytest.mark.asyncio
     async def test_acquire_returns_session(self, pool):
@@ -245,6 +246,73 @@ class TestStatelessSessionPool:
         assert "old-session" not in pool._sessions
         mock_delete_session.assert_awaited_once_with("old-session")
 
+    @pytest.mark.asyncio
+    async def test_acquire_raises_when_pool_full_and_timeout(self, pool):
+        """Pool at capacity with all sessions locked — acquire should time out."""
+        pool._acquire_timeout = 0.1  # Short timeout for test speed
+
+        # Fill pool to capacity
+        for i in range(pool._pool_size):
+            s = StatelessSession(chat_session_id=f"busy-{i}")
+            await s.lock.acquire()
+            pool._sessions[f"busy-{i}"] = s
+
+        with pytest.raises(SessionPoolFullError):
+            await pool.acquire()
+
+    @pytest.mark.asyncio
+    async def test_acquire_unblocks_when_session_released(self, pool):
+        """Waiter in acquire() should receive the session once release() is called."""
+        pool._acquire_timeout = 5.0
+
+        # Fill pool to capacity with locked sessions
+        sessions = []
+        for i in range(pool._pool_size):
+            s = StatelessSession(chat_session_id=f"busy-{i}")
+            await s.lock.acquire()
+            pool._sessions[f"busy-{i}"] = s
+            sessions.append(s)
+
+        # Start acquire in background — will block until a session is released
+        acquire_task = asyncio.create_task(pool.acquire())
+        await asyncio.sleep(0.05)  # Let acquire() reach the wait state
+
+        # Release one session
+        await pool.release(sessions[0])
+
+        acquired = await asyncio.wait_for(acquire_task, timeout=2.0)
+        assert acquired.chat_session_id == "busy-0"
+        assert acquired.lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_acquire_respects_pending_creates_as_reserved_slots(self, pool):
+        """_pending_creates should count toward effective pool size to prevent over-creation."""
+        # Pool size 5, 0 sessions, 4 pending creates
+        pool._pending_creates = 4
+
+        created_count = 0
+
+        async def slow_create():
+            nonlocal created_count
+            await asyncio.sleep(0.05)
+            created_count += 1
+            return StatelessSession(chat_session_id=f"created-{created_count}")
+
+        with patch.object(pool, '_create_session', new=slow_create):
+            # Only 1 slot left — only one concurrent create should proceed immediately
+            task1 = asyncio.create_task(pool.acquire())
+            await asyncio.sleep(0.01)
+            # Effective size is now 5 (0 + 4 + 1 pending), pool is full
+            # Manually verify _pending_creates got incremented for task1
+            assert pool._pending_creates == 5
+
+            # Cancel task1 to avoid hanging test (it's blocked on slow_create)
+            task1.cancel()
+            try:
+                await task1
+            except (asyncio.CancelledError, Exception):
+                pass
+
 
 class TestGetPool:
     """Tests for get_pool function."""
@@ -272,6 +340,7 @@ class TestGetPool:
         assert isinstance(pool, StatelessSessionPool)
         assert pool._max_idle_seconds == 300
         assert pool._pool_size == 10
+        assert pool._acquire_timeout == 30.0
 
         # Cleanup
         await pool.stop_cleanup()

--- a/tests/api/test_v0_service.py
+++ b/tests/api/test_v0_service.py
@@ -467,3 +467,193 @@ class TestParseSseResponseMessageId:
         result = v0_service.parse_sse_response_message_id(b"invalid")
 
         assert result is None
+
+
+class TestParseRetryAfter:
+    """Test _parse_retry_after helper."""
+
+    def test_returns_float_seconds(self):
+        assert v0_service._parse_retry_after("10") == 10.0
+        assert v0_service._parse_retry_after("30.5") == 30.5
+
+    def test_returns_zero_for_none(self):
+        assert v0_service._parse_retry_after(None) == 0.0
+
+    def test_returns_zero_for_empty(self):
+        assert v0_service._parse_retry_after("") == 0.0
+
+    def test_returns_zero_for_unparseable(self):
+        assert v0_service._parse_retry_after("not-a-number") == 0.0
+
+    def test_clamps_negative_to_zero(self):
+        assert v0_service._parse_retry_after("-5") == 0.0
+
+
+class TestProxyToDeepseekStreamRateLimit:
+    """Test rate limit detection in proxy_to_deepseek_stream."""
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.get_auth_headers")
+    @patch("deepseek_web_api.api.v0_service.httpx.AsyncClient")
+    async def test_raises_rate_limit_error_on_429(self, mock_client_class, mock_get_auth):
+        mock_get_auth.return_value = {"authorization": "Bearer test"}
+
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 429
+        mock_resp.headers = {"Retry-After": "15"}
+        mock_resp.aread = AsyncMock(return_value=b'rate limited')
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_client = MagicMock()
+        mock_client.stream.return_value = mock_resp
+        mock_client_cm = AsyncMock()
+        mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client_cm
+
+        with pytest.raises(v0_service.RateLimitError) as exc_info:
+            async for _ in v0_service.proxy_to_deepseek_stream("POST", "api/v0/test"):
+                pass
+
+        assert exc_info.value.retry_after == 15.0
+        assert "429" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.get_auth_headers")
+    @patch("deepseek_web_api.api.v0_service.httpx.AsyncClient")
+    async def test_raises_rate_limit_error_on_5xx(self, mock_client_class, mock_get_auth):
+        mock_get_auth.return_value = {"authorization": "Bearer test"}
+
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 503
+        mock_resp.headers = {}
+        mock_resp.aread = AsyncMock(return_value=b'service unavailable')
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_client = MagicMock()
+        mock_client.stream.return_value = mock_resp
+        mock_client_cm = AsyncMock()
+        mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client_cm
+
+        with pytest.raises(v0_service.RateLimitError) as exc_info:
+            async for _ in v0_service.proxy_to_deepseek_stream("POST", "api/v0/test"):
+                pass
+
+        assert exc_info.value.retry_after == 5.0
+        assert "503" in str(exc_info.value)
+
+
+class TestStreamRateLimitRetry:
+    """Test rate limit retry logic in stream_chat_completion and stream_edit_message."""
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deepseek_web_api.api.v0_service.get_pow_response")
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek_stream")
+    @patch("deepseek_web_api.api.v0_service.create_session")
+    async def test_stream_chat_retries_on_rate_limit(
+        self, mock_create, mock_stream, mock_pow, mock_sleep, reset_parent_msg_store
+    ):
+        """stream_chat_completion retries after rate limit and succeeds."""
+        mock_create.return_value = ("session-rl", MagicMock())
+        mock_pow.return_value = "pow-token"
+
+        async def rate_limited():
+            raise v0_service.RateLimitError("HTTP 429", retry_after=0.0)
+            yield  # make it an async generator
+
+        async def success():
+            yield b'data: {"response_message_id": 5}\n\n'
+
+        mock_stream.side_effect = [rate_limited(), success()]
+
+        chunks = []
+        async for chunk in v0_service.stream_chat_completion("Hello"):
+            chunks.append(chunk)
+
+        assert mock_stream.call_count == 2
+        mock_sleep.assert_called_once()  # Waited before retry
+        assert len(chunks) > 0
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deepseek_web_api.api.v0_service.get_pow_response")
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek_stream")
+    @patch("deepseek_web_api.api.v0_service.create_session")
+    async def test_stream_chat_raises_after_all_retries(
+        self, mock_create, mock_stream, mock_pow, mock_sleep, reset_parent_msg_store
+    ):
+        """stream_chat_completion raises RateLimitError after all retries exhausted."""
+        mock_create.return_value = ("session-rl2", MagicMock())
+        mock_pow.return_value = "pow-token"
+
+        async def rate_limited():
+            raise v0_service.RateLimitError("HTTP 429", retry_after=0.0)
+            yield
+
+        mock_stream.side_effect = [rate_limited(), rate_limited(), rate_limited()]
+
+        with pytest.raises(v0_service.RateLimitError):
+            async for _ in v0_service.stream_chat_completion("Hello"):
+                pass
+
+        assert mock_stream.call_count == v0_service._MAX_RATE_LIMIT_RETRIES
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deepseek_web_api.api.v0_service.get_pow_response")
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek_stream")
+    async def test_stream_edit_retries_on_rate_limit(
+        self, mock_stream, mock_pow, mock_sleep, reset_parent_msg_store
+    ):
+        """stream_edit_message retries after rate limit and succeeds."""
+        mock_pow.return_value = "pow-token"
+
+        async def rate_limited():
+            raise v0_service.RateLimitError("HTTP 429", retry_after=0.0)
+            yield
+
+        async def success():
+            yield b'data: {"response_message_id": 7}\n\n'
+
+        mock_stream.side_effect = [rate_limited(), success()]
+
+        chunks = []
+        async for chunk in v0_service.stream_edit_message("Hello", chat_session_id="sess-edit"):
+            chunks.append(chunk)
+
+        assert mock_stream.call_count == 2
+        mock_sleep.assert_called_once()
+        assert len(chunks) > 0
+
+    @pytest.mark.asyncio
+    @patch("deepseek_web_api.api.v0_service.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deepseek_web_api.api.v0_service.get_pow_response")
+    @patch("deepseek_web_api.api.v0_service.proxy_to_deepseek_stream")
+    @patch("deepseek_web_api.api.v0_service.create_session")
+    async def test_retry_delay_respects_retry_after_header(
+        self, mock_create, mock_stream, mock_pow, mock_sleep, reset_parent_msg_store
+    ):
+        """Retry delay uses the larger of base delay and Retry-After."""
+        mock_create.return_value = ("session-rl3", MagicMock())
+        mock_pow.return_value = "pow-token"
+
+        async def rate_limited_with_header():
+            raise v0_service.RateLimitError("HTTP 429", retry_after=60.0)
+            yield
+
+        async def success():
+            yield b'data: {}\n\n'
+
+        mock_stream.side_effect = [rate_limited_with_header(), success()]
+
+        async for _ in v0_service.stream_chat_completion("Hello"):
+            pass
+
+        # Delay should be at least the Retry-After value (60s), not just base delay (5s)
+        sleep_call_arg = mock_sleep.call_args[0][0]
+        assert sleep_call_arg >= 60.0


### PR DESCRIPTION
## 摘要

这个 PR 修复了并发负载下触发 DeepSeek 账号级限流的根本原因。

本次包含两个相互独立的修复：

- **P0**：将 `pool_size` 真正作为 session pool 的硬上限；当池已满时，请求会阻塞等待空闲 session，而不是继续无界创建新 session
- **P1**：在流式路径中，在产出任何字节之前先检测 HTTP 429/5xx；如果命中限流或上游错误，则使用指数退避重试，而不是把损坏的错误数据静默转发给客户端

关联：issue #4

## 根因分析

### 1. Session pool 无界增长（P0）

`StatelessSessionPool.acquire()` 在现有 session 全部忙碌时，总是直接创建新的 DeepSeek session。每个新 session 都会触发 3 次上游请求（创建 session + PoW challenge + 一次 completion 以初始化 `message_id=1`）。在 N 个并发请求下，这会放大成 3N 个同时发出的上游请求，非常容易触发账号级限流。

问题在于：`pool_size=10` 虽然被读取和保存了，但此前从未真正生效。

### 2. 流式路径缺少 HTTP 错误感知（P1）

`proxy_to_deepseek_stream()` 之前会无条件地直接产出字节流。当 DeepSeek 返回 HTTP 429 时，错误载荷会被当作 SSE 数据直接透传，导致响应被污染，同时也不会触发任何重试。

## 变更内容

### P0：为 session pool 增加硬上限与阻塞等待机制

**`session_pool.py`**：
- 新增 `SessionPoolFullError`，用于区分池已满与其他 session 错误
- 将 `asyncio.Lock` 替换为 `asyncio.Condition`，以便正确实现等待/唤醒协调
- 新增 `_pending_creates` 计数器，把正在进行中的 session 创建也算作已占用槽位，避免多个并发 `acquire()` 在锁外执行 HTTP 调用时突破上限
- 将 `acquire()` 重写为三阶段循环：扫描空闲 session → 预留槽位并在锁外创建 → 回到锁内注册并返回
- 在 `release()` 中增加 `notify_all()`，用于唤醒等待中的调用方
- 新增 `acquire_timeout` 参数（默认 30 秒）；超时后抛出 `SessionPoolFullError`

**`config.py`**：
- 新增 `get_pool_size() -> int`（读取 `[server].pool_size`，默认值 10，环境变量为 `DEEPSEEK_WEB_POOL_SIZE`）
- 新增 `get_pool_acquire_timeout() -> float`（读取 `[server].pool_acquire_timeout`，默认值 30.0，环境变量为 `DEEPSEEK_WEB_POOL_ACQUIRE_TIMEOUT`）

**`route.py`**：捕获 `SessionPoolFullError`
- 流式请求：返回 SSE 错误块
- 非流式请求：返回 HTTP 503

**`config.toml.example`**：补充 `pool_size` 与 `pool_acquire_timeout` 配置说明

### P1：在流式路径中增加限流检测与指数退避重试

**`v0_service.py`**：
- 新增 `RateLimitError(retry_after: float)` 异常
- 新增 `_parse_retry_after()` 辅助函数
- 在 `proxy_to_deepseek_stream()` 中，在进入 `aiter_bytes()` 之前先检查 HTTP 状态码：
  - HTTP 429：抛出 `RateLimitError`，并尽量读取 `Retry-After`
  - HTTP 5xx：抛出 `RateLimitError(retry_after=5.0)`
- 在 `stream_chat_completion()` / `stream_edit_message()` 中，最多重试 3 次；延迟为 `max(base × 2^n, retry_after)`，即 5 秒 → 10 秒 → 20 秒，每次重试都重新获取新的 PoW

**`route.py`**：单独捕获 `RateLimitError`
- 不再切换到其他 session 重试，因为这种限流通常是账号/IP 级别的
- 对外统一返回 HTTP 503 或 SSE 错误块

## 测试

新增或扩展了以下测试：

- `test_session_pool.py`：池满超时、`release()` 唤醒等待者、`_pending_creates` 槽位预留
- `test_v0_service.py`：`_parse_retry_after()` 边界情况、429/5xx 检测、重试后成功、重试耗尽、`Retry-After` 生效

## 验证

```text
tests/api + tests/core:  163 passed
tests/smoke (真实 API):   11 passed
Total:                   174 passed, 0 failed
```

## 兼容性说明

- `pool_size` / `pool_acquire_timeout` 都有默认值（10 / 30.0）；如果不显式配置，除“现在真的会执行上限约束”之外，其余行为与之前保持一致
- 保留 `AllSessionsBusyError`，以兼容既有调用方
- 对非 429/5xx 的正常流式路径没有行为变化