### PR TITLE
Update DeepSeek V4 token limits: 1M context and 262144 output

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -80,11 +80,11 @@ fn default_model_types() -> Vec<String> {
 }
 
 fn default_max_input_tokens() -> Vec<u32> {
-    vec![128_000, 1_000_000]
+    vec![1048576, 1048576]
 }
 
 fn default_max_output_tokens() -> Vec<u32> {
-    vec![16_384, 16_384]
+    vec![262144, 262144]
 }
 
 impl DeepSeekConfig {


### PR DESCRIPTION
## Summary
Updates DeepSeek V4 model token limits in ds-free-api proxy to match actual DeepSeek V4 Pro and Flash capabilities.

## Changes
- Update `default_max_input_tokens` to `vec![1048576, 1048576]` (true 1M context for both expert and default models)
- Update `default_max_output_tokens` to `vec![262144, 262144]` (256K output for both models)

## Background
- DeepSeek V4 Pro corresponds to `deepseek-expert` model
- DeepSeek V4 Flash corresponds to `deepseek-default` model
- Previous defaults were 128K/1M input and 16K output

## Testing
- Built successfully with `cargo build --release`
- Verified proxy `/v1/models` endpoint returns correct token limits:
  - `deepseek-expert`: input=1048576, output=262144
  - `deepseek-default`: input=1048576, output=262144
- Tested with omp and hermes agents - both work correctly with updated proxy

## Notes
- `config.toml` can override these defaults with explicit `max_input_tokens` and `max_output_tokens` values
- Users should update their local `config.toml` if they want to customize token limits