### PR TITLE
feat: Add x-ds-account response header for account tracking

### DIFF
--- a/examples/adapter_cli.rs
+++ b/examples/adapter_cli.rs
@@ -110,7 +110,9 @@ async fn handle_line(line: &str, adapter: &OpenAIAdapter) -> anyhow::Result<bool
             let file = parts[1];
             let body = load_json(file)?;
             println!(">>> chat: {}", file);
-            let mut stream = adapter.chat_completions_stream(&body).await?;
+            let result = adapter.chat_completions_stream(&body).await?;
+            println!("[account: {}]", result.account_id);
+            let mut stream = result.data;
             print_stream(&mut stream, false).await;
         }
 
@@ -118,7 +120,9 @@ async fn handle_line(line: &str, adapter: &OpenAIAdapter) -> anyhow::Result<bool
             let file = parts[1];
             let body = load_json(file)?;
             println!(">>> raw: {}", file);
-            let mut stream = adapter.raw_chat_stream(&body).await?;
+            let result = adapter.raw_chat_stream(&body).await?;
+            println!("[account: {}]", result.account_id);
+            let mut stream = result.data;
             print_stream(&mut stream, true).await;
         }
 
@@ -129,8 +133,9 @@ async fn handle_line(line: &str, adapter: &OpenAIAdapter) -> anyhow::Result<bool
 
             // 原始流
             println!("\n═══ RAW DEEPSEEK SSE ═══════════════════════════════════════");
-            let raw_stream = adapter.raw_chat_stream(&body).await?;
-            consume_stream(raw_stream, |bytes| {
+            let raw_result = adapter.raw_chat_stream(&body).await?;
+            println!("[account: {}]", raw_result.account_id);
+            consume_stream(raw_result.data, |bytes| {
                 let text = String::from_utf8_lossy(&bytes);
                 for line in text.lines() {
                     println!("  {}", line);
@@ -140,8 +145,9 @@ async fn handle_line(line: &str, adapter: &OpenAIAdapter) -> anyhow::Result<bool
 
             // 转换后流
             println!("\n═══ CONVERTED OPENAI SSE ═══════════════════════════════════");
-            let converted_stream = adapter.chat_completions_stream(&body).await?;
-            consume_stream(converted_stream, |bytes| {
+            let converted_result = adapter.chat_completions_stream(&body).await?;
+            println!("[account: {}]", converted_result.account_id);
+            consume_stream(converted_result.data, |bytes| {
                 let text = String::from_utf8_lossy(&bytes);
                 for line in text.lines() {
                     println!("  {}", line);
@@ -337,7 +343,8 @@ async fn run_concurrent(adapter: &OpenAIAdapter, count: usize, body: Vec<u8>, ra
                 let req_start = std::time::Instant::now();
                 let result = if is_streaming {
                     match adapter.chat_completions_stream(&body).await {
-                        Ok(mut stream) => {
+                        Ok(result) => {
+                            let mut stream = result.data;
                             let mut output = String::new();
                             let mut ok = true;
                             while let Some(chunk) = stream.next().await {
@@ -392,7 +399,8 @@ async fn run_concurrent(adapter: &OpenAIAdapter, count: usize, body: Vec<u8>, ra
                     }
                 } else {
                     match adapter.chat_completions(&body).await {
-                        Ok(json) => {
+                        Ok(result) => {
+                            let json = result.data;
                             let output = if raw {
                                 String::from_utf8_lossy(&json).to_string()
                             } else {

--- a/src/anthropic_compat.rs
+++ b/src/anthropic_compat.rs
@@ -17,7 +17,7 @@ use bytes::Bytes;
 use futures::Stream;
 use log::debug;
 
-use crate::openai_adapter::{OpenAIAdapter, OpenAIAdapterError};
+use crate::openai_adapter::{ChatResult, OpenAIAdapter, OpenAIAdapterError};
 
 /// Anthropic 兼容层
 pub struct AnthropicCompat {
@@ -33,12 +33,16 @@ impl AnthropicCompat {
     /// POST /v1/messages (非流式)
     ///
     /// 将 Anthropic 请求映射为 OpenAI 请求，获取响应后再映射回 Anthropic Message 格式。
-    pub async fn messages(&self, body: &[u8]) -> Result<Vec<u8>, AnthropicCompatError> {
+    pub async fn messages(&self, body: &[u8]) -> Result<ChatResult<Vec<u8>>, AnthropicCompatError> {
         debug!(target: "anthropic_compat", "收到 messages 请求");
         let openai_body = request::to_openai_request(body)?;
-        let openai_json = self.openai_adapter.chat_completions(&openai_body).await?;
-        response::from_chat_completion_bytes(&openai_json)
-            .map_err(|e| AnthropicCompatError::Internal(format!("json error: {}", e)))
+        let result = self.openai_adapter.chat_completions(&openai_body).await?;
+        let anthropic_json = response::from_chat_completion_bytes(&result.data)
+            .map_err(|e| AnthropicCompatError::Internal(format!("json error: {}", e)))?;
+        Ok(ChatResult {
+            data: anthropic_json,
+            account_id: result.account_id,
+        })
     }
 
     /// POST /v1/messages (流式)
@@ -47,7 +51,7 @@ impl AnthropicCompat {
     pub async fn messages_stream(
         &self,
         body: &[u8],
-    ) -> Result<StreamResponse, AnthropicCompatError> {
+    ) -> Result<ChatResult<StreamResponse>, AnthropicCompatError> {
         debug!(target: "anthropic_compat", "收到流式 messages 请求");
         let openai_body = request::to_openai_request(body)?;
         let openai_req = self
@@ -55,23 +59,27 @@ impl AnthropicCompat {
             .parse_request(&openai_body)
             .map_err(AnthropicCompatError::from)?;
         let input_tokens = openai_req.prompt_tokens;
-        let ds_stream = self
+        let chat_resp = self
             .openai_adapter
             .try_chat(openai_req.ds_req)
             .await
             .map_err(OpenAIAdapterError::from)?;
+        let account_id = chat_resp.account_id;
         let openai_stream = crate::openai_adapter::response::stream(
-            ds_stream,
+            chat_resp.stream,
             openai_req.model,
             openai_req.include_usage,
             openai_req.include_obfuscation,
             openai_req.stop,
             openai_req.prompt_tokens,
         );
-        Ok(response::from_chat_completion_stream(
-            openai_stream,
-            input_tokens,
-        ))
+        Ok(ChatResult {
+            data: response::from_chat_completion_stream(
+                openai_stream,
+                input_tokens,
+            ),
+            account_id,
+        })
     }
 
     /// GET /v1/models

--- a/src/ds_core.rs
+++ b/src/ds_core.rs
@@ -8,9 +8,7 @@ mod completions;
 mod pow;
 
 pub use accounts::AccountStatus;
-pub use completions::ChatRequest;
-
-use std::pin::Pin;
+pub use completions::{ChatRequest, ChatResponse};
 
 use crate::config::Config;
 use accounts::AccountPool;
@@ -90,10 +88,7 @@ impl DeepSeekCore {
     pub async fn v0_chat(
         &self,
         req: ChatRequest,
-    ) -> Result<
-        Pin<Box<dyn futures::Stream<Item = Result<bytes::Bytes, CoreError>> + Send>>,
-        CoreError,
-    > {
+    ) -> Result<ChatResponse, CoreError> {
         self.completions.v0_chat(req).await
     }
 

--- a/src/ds_core/accounts.rs
+++ b/src/ds_core/accounts.rs
@@ -43,6 +43,15 @@ impl Account {
     pub fn is_busy(&self) -> bool {
         self.is_busy.load(Ordering::Relaxed)
     }
+
+    /// 可展示的账号标识（优先 email，否则 mobile）
+    pub fn display_id(&self) -> &str {
+        if !self.email.is_empty() {
+            &self.email
+        } else {
+            &self.mobile
+        }
+    }
 }
 
 /// 持有期间账号标记为 busy，Drop 时自动释放

--- a/src/ds_core/completions.rs
+++ b/src/ds_core/completions.rs
@@ -58,6 +58,13 @@ where
     }
 }
 
+/// v0_chat 的返回结果，包含 SSE 流和使用的账号标识
+pub struct ChatResponse {
+    pub stream: Pin<Box<dyn Stream<Item = Result<Bytes, CoreError>> + Send>>,
+    /// 使用的账号标识（优先 email，否则 mobile）
+    pub account_id: String,
+}
+
 pub struct Completions {
     client: DsClient,
     solver: PowSolver,
@@ -76,7 +83,7 @@ impl Completions {
     pub async fn v0_chat(
         &self,
         req: ChatRequest,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes, CoreError>> + Send>>, CoreError> {
+    ) -> Result<ChatResponse, CoreError> {
         let guard = self
             .pool
             .get_account(&req.model_type)
@@ -84,6 +91,7 @@ impl Completions {
 
         let account = guard.account();
         let token = account.token().to_string();
+        let account_id = account.display_id().to_string();
         let session_id = account
             .session_id(&req.model_type)
             .expect("初始化时已保证存在该 model_type 的 session")
@@ -105,7 +113,10 @@ impl Completions {
             .edit_message(&token, &pow_header, &payload)
             .await?;
 
-        Ok(Box::pin(GuardedStream::new(stream, guard)))
+        Ok(ChatResponse {
+            stream: Box::pin(GuardedStream::new(stream, guard)),
+            account_id,
+        })
     }
 
     async fn compute_pow(&self, token: &str) -> Result<String, CoreError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ pub mod server;
 pub use anthropic_compat::AnthropicCompat;
 pub use config::Config;
 pub use ds_core::{AccountStatus, ChatRequest, CoreError, DeepSeekCore};
-pub use openai_adapter::{OpenAIAdapter, OpenAIAdapterError, StreamResponse};
+pub use openai_adapter::{ChatResult, OpenAIAdapter, OpenAIAdapterError, StreamResponse};

--- a/src/openai_adapter.rs
+++ b/src/openai_adapter.rs
@@ -19,6 +19,12 @@ mod types;
 /// 流式响应类型
 pub type StreamResponse = Pin<Box<dyn Stream<Item = Result<Bytes, OpenAIAdapterError>> + Send>>;
 
+/// chat completions 结果，包含响应数据和使用的账号标识
+pub struct ChatResult<T> {
+    pub data: T,
+    pub account_id: String,
+}
+
 /// OpenAI 适配器
 pub struct OpenAIAdapter {
     ds_core: DeepSeekCore,
@@ -53,40 +59,47 @@ impl OpenAIAdapter {
     /// POST /v1/chat/completions (非流式)
     ///
     /// 底层复用流式接口，将 SSE 流聚合为单个 JSON 对象后返回
-    pub async fn chat_completions(&self, body: &[u8]) -> Result<Vec<u8>, OpenAIAdapterError> {
+    pub async fn chat_completions(&self, body: &[u8]) -> Result<ChatResult<Vec<u8>>, OpenAIAdapterError> {
         let req = request::parse(body, &self.model_registry)?;
-        let stream = self.try_chat(req.ds_req).await?;
-        response::aggregate(stream, req.model, req.stop, req.prompt_tokens).await
+        let chat_resp = self.try_chat(req.ds_req).await?;
+        let json = response::aggregate(chat_resp.stream, req.model, req.stop, req.prompt_tokens).await?;
+        Ok(ChatResult {
+            data: json,
+            account_id: chat_resp.account_id,
+        })
     }
 
     /// POST /v1/chat/completions (流式)
     pub async fn chat_completions_stream(
         &self,
         body: &[u8],
-    ) -> Result<StreamResponse, OpenAIAdapterError> {
+    ) -> Result<ChatResult<StreamResponse>, OpenAIAdapterError> {
         let req = request::parse(body, &self.model_registry)?;
-        let stream = self.try_chat(req.ds_req).await?;
-        Ok(response::stream(
-            stream,
-            req.model,
-            req.include_usage,
-            req.include_obfuscation,
-            req.stop,
-            req.prompt_tokens,
-        ))
+        let chat_resp = self.try_chat(req.ds_req).await?;
+        Ok(ChatResult {
+            data: response::stream(
+                chat_resp.stream,
+                req.model,
+                req.include_usage,
+                req.include_obfuscation,
+                req.stop,
+                req.prompt_tokens,
+            ),
+            account_id: chat_resp.account_id,
+        })
     }
 
     /// 内部辅助：对 `Overloaded` 进行短延迟轮询重试，降低瞬时并发峰值导致的失败率
     pub(crate) async fn try_chat(
         &self,
         req: crate::ds_core::ChatRequest,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes, CoreError>> + Send>>, CoreError> {
+    ) -> Result<crate::ds_core::ChatResponse, CoreError> {
         const MAX_RETRIES: usize = 3;
         const RETRY_DELAY_MS: u64 = 200;
 
         for attempt in 0..MAX_RETRIES {
             match self.ds_core.v0_chat(req.clone()).await {
-                Ok(stream) => return Ok(Box::pin(stream)),
+                Ok(resp) => return Ok(resp),
                 Err(CoreError::Overloaded) if attempt + 1 < MAX_RETRIES => {
                     tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
                 }
@@ -118,12 +131,15 @@ impl OpenAIAdapter {
     /// 原始 DeepSeek SSE 流（不经 OpenAI 协议转换）
     ///
     /// 用于流分析：对比原始响应与 OpenAI 转换后的差异，定位转换 bug
-    pub async fn raw_chat_stream(&self, body: &[u8]) -> Result<StreamResponse, OpenAIAdapterError> {
+    pub async fn raw_chat_stream(&self, body: &[u8]) -> Result<ChatResult<StreamResponse>, OpenAIAdapterError> {
         let req = request::parse(body, &self.model_registry)?;
-        let stream = self.try_chat(req.ds_req).await?;
-        Ok(Box::pin(
-            stream.map(|r| r.map_err(OpenAIAdapterError::from)),
-        ))
+        let chat_resp = self.try_chat(req.ds_req).await?;
+        Ok(ChatResult {
+            data: Box::pin(
+                chat_resp.stream.map(|r| r.map_err(OpenAIAdapterError::from)),
+            ),
+            account_id: chat_resp.account_id,
+        })
     }
 
     /// 获取 ds_core 账号池状态

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -18,6 +18,9 @@ use crate::openai_adapter::{OpenAIAdapter, OpenAIAdapterError, StreamResponse};
 use super::error::ServerError;
 use super::stream::SseBody;
 
+/// x-ds-account 自定义响应头名
+const X_DS_ACCOUNT: &str = "x-ds-account";
+
 /// 应用状态
 #[derive(Clone)]
 pub(crate) struct AppState {
@@ -34,32 +37,44 @@ pub(crate) async fn chat_completions(
     log::debug!(target: "http::request", "POST /v1/chat/completions stream={}", req.stream);
 
     match handle_chat(&state.adapter, req).await {
-        Ok(ChatResult::Stream(stream)) => {
-            log::debug!(target: "http::response", "200 SSE stream started");
-            Ok(SseBody::new(stream).into_response())
+        Ok(ChatHandlerResult::Stream {
+            stream,
+            account_id,
+        }) => {
+            log::debug!(target: "http::response", "200 SSE stream started account={}", account_id);
+            Ok(SseBody::new(stream)
+                .with_header(X_DS_ACCOUNT, &account_id)
+                .into_response())
         }
-        Ok(ChatResult::Json(json)) => {
-            log::debug!(target: "http::response", "200 JSON response {} bytes", json.len());
-            Ok((
-                StatusCode::OK,
-                [(header::CONTENT_TYPE, "application/json")],
-                Body::from(json),
-            )
+        Ok(ChatHandlerResult::Json { json, account_id }) => {
+            log::debug!(target: "http::response", "200 JSON response {} bytes account={}", json.len(), account_id);
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(X_DS_ACCOUNT, &account_id)
+                .body(Body::from(json))
+                .unwrap()
                 .into_response())
         }
         Err(e) => Err(e.into()),
     }
 }
 
-enum ChatResult {
-    Stream(StreamResponse),
-    Json(Vec<u8>),
+enum ChatHandlerResult {
+    Stream {
+        stream: StreamResponse,
+        account_id: String,
+    },
+    Json {
+        json: Vec<u8>,
+        account_id: String,
+    },
 }
 
 async fn handle_chat(
     adapter: &OpenAIAdapter,
     req: AdapterRequest,
-) -> Result<ChatResult, OpenAIAdapterError> {
+) -> Result<ChatHandlerResult, OpenAIAdapterError> {
     let model = req.model.clone();
     let stop = req.stop.clone();
     let stream = req.stream;
@@ -67,24 +82,35 @@ async fn handle_chat(
     let include_obfuscation = req.include_obfuscation;
     let prompt_tokens = req.prompt_tokens;
 
-    let ds_stream = adapter.try_chat(req.ds_req).await?;
+    let chat_resp = adapter.try_chat(req.ds_req).await?;
+    let account_id = chat_resp.account_id;
 
     if stream {
         log::debug!(target: "http::response", "200 SSE stream started");
-        Ok(ChatResult::Stream(crate::openai_adapter::response::stream(
-            ds_stream,
+        Ok(ChatHandlerResult::Stream {
+            stream: crate::openai_adapter::response::stream(
+                chat_resp.stream,
+                model,
+                include_usage,
+                include_obfuscation,
+                stop,
+                prompt_tokens,
+            ),
+            account_id,
+        })
+    } else {
+        let json = crate::openai_adapter::response::aggregate(
+            chat_resp.stream,
             model,
-            include_usage,
-            include_obfuscation,
             stop,
             prompt_tokens,
-        )))
-    } else {
-        let json =
-            crate::openai_adapter::response::aggregate(ds_stream, model, stop, prompt_tokens)
-                .await?;
+        )
+        .await?;
         log::debug!(target: "http::response", "200 JSON response {} bytes", json.len());
-        Ok(ChatResult::Json(json))
+        Ok(ChatHandlerResult::Json {
+            json,
+            account_id,
+        })
     }
 }
 
@@ -140,17 +166,20 @@ pub(crate) async fn anthropic_messages(
     log::debug!(target: "http::request", "POST /anthropic/v1/messages stream={}", stream);
 
     if stream {
-        let anthropic_stream = state.anthropic_compat.messages_stream(&body).await?;
-        log::debug!(target: "http::response", "200 SSE stream started");
-        Ok(SseBody::new(anthropic_stream).into_response())
+        let result = state.anthropic_compat.messages_stream(&body).await?;
+        log::debug!(target: "http::response", "200 SSE stream started account={}", result.account_id);
+        Ok(SseBody::new(result.data)
+            .with_header(X_DS_ACCOUNT, &result.account_id)
+            .into_response())
     } else {
-        let json = state.anthropic_compat.messages(&body).await?;
-        log::debug!(target: "http::response", "200 JSON response {} bytes", json.len());
-        Ok((
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            Body::from(json),
-        )
+        let result = state.anthropic_compat.messages(&body).await?;
+        log::debug!(target: "http::response", "200 JSON response {} bytes account={}", result.data.len(), result.account_id);
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(X_DS_ACCOUNT, &result.account_id)
+            .body(Body::from(result.data))
+            .unwrap()
             .into_response())
     }
 }

--- a/src/server/stream.rs
+++ b/src/server/stream.rs
@@ -14,6 +14,7 @@ use futures::StreamExt;
 /// SSE 响应体包装器（泛型）
 pub struct SseBody<S> {
     inner: S,
+    extra_headers: Vec<(String, String)>,
 }
 
 impl<S, E> SseBody<S>
@@ -22,7 +23,16 @@ where
     E: std::fmt::Display + Send + Sync + 'static,
 {
     pub fn new(stream: S) -> Self {
-        Self { inner: stream }
+        Self {
+            inner: stream,
+            extra_headers: Vec::new(),
+        }
+    }
+
+    /// 添加自定义响应头
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.extra_headers.push((name.to_string(), value.to_string()));
+        self
     }
 }
 
@@ -39,15 +49,16 @@ where
             })
         }));
 
-        (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "text/event-stream"),
-                (header::CACHE_CONTROL, "no-cache"),
-                (header::CONNECTION, "keep-alive"),
-            ],
-            body,
-        )
-            .into_response()
+        let mut builder = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CACHE_CONTROL, "no-cache")
+            .header(header::CONNECTION, "keep-alive");
+
+        for (name, value) in &self.extra_headers {
+            builder = builder.header(name.as_str(), value.as_str());
+        }
+
+        builder.body(body).unwrap().into_response()
     }
 }


### PR DESCRIPTION
**What does this PR do?**
This PR introduces a new custom HTTP response header x-ds-account that exposes the identifier of the DeepSeek account (email or mobile fraction) used to serve the incoming request.

This is particularly useful for debugging, monitoring, and load-balancing observability in production, allowing consumers matching logs and tracking account rotation usage without needing to query internal server states.

**Key Changes**
1. Account Identification: Added a display_id() method to ds_core::accounts::Account to consistently provide the account's email (primary) or mobile number (fallback).

2. Propagating Context:
- Refactored ds_core::Completions::v0_chat to return a ChatResponse structured tuple containing both the SSE stream and the account_id.
- Propagated this context up through the OpenAIAdapter using a generic ChatResult<T> struct, preserving the account identifier alongside the underlying response payload (e.g., SSE stream or aggregated JSON).
- Applied the same context passing to the AnthropicCompat layer.

3. HTTP Handlers: Updated server/handlers.rs to intercept these ChatResults and inject the x-ds-account header into the final Axum Response.
4. SSE Stream Headers: Extended the SseBody wrapper (server/stream.rs) with a with_header() builder method to inject custom headers before yielding the HTTP stream.
5. CLI Utility: Updated examples/adapter_cli.rs to destructure the new ChatResult return type and log the used account into standard output ([account: ...]).

**Compatibility**
✅ OpenAI Endpoints (/v1/chat/completions) - Streaming & Non-streaming
✅ Anthropic Endpoints (/anthropic/v1/messages) - Streaming & Non-streaming
Fully backwards compatible with existing API schemas.

**Testing**
- Existing tests pass (cargo test --lib).
- Validated via adapter_cli confirming the account identifier displays correctly for both formats.
- Confirmed x-ds-account propagates correctly on curl evaluations.