### PR TITLE
[codex] harden anthropic stream completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ lerna-debug.log*
 # 呃
 .claude
 .deepseek
+.rustup-codex

--- a/docs/docker-dev-run.md
+++ b/docs/docker-dev-run.md
@@ -1,0 +1,123 @@
+# Docker 一键构建与测试
+
+这套脚本用于本地快速验证：构建前端、用 Docker 中的 Rust 1.95.0 编译后端、生成 Docker 可访问的临时配置、启动测试容器。
+
+## Windows
+
+```powershell
+.\scripts\dev-docker-run.ps1 -ConfigPath "D:\codes\free-apis\ds-free-api-v0.2.6-windows-x86_64\config.toml"
+```
+
+## macOS / Linux
+
+```bash
+chmod +x scripts/dev-docker-run.sh
+./scripts/dev-docker-run.sh --config /path/to/config.toml
+```
+
+启动后访问：
+
+```text
+http://127.0.0.1:22217/health
+http://127.0.0.1:22217/admin
+```
+
+## 加速源
+
+脚本只在本次执行中注入加速源：
+
+- Bun/npm：`https://registry.npmmirror.com`
+- Cargo：`sparse+https://rsproxy.cn/index/`
+- Debian apt：`https://mirrors.tuna.tsinghua.edu.cn/debian`
+
+不会修改用户全局 Cargo、Bun、npm 或系统 apt 配置。
+
+## 参数
+
+Windows：
+
+```powershell
+.\scripts\dev-docker-run.ps1 `
+  -ConfigPath .\config.toml `
+  -Port 22217 `
+  -ContainerName ds-free-api-test `
+  -SkipFrontend `
+  -SkipBuild
+```
+
+macOS / Linux：
+
+```bash
+./scripts/dev-docker-run.sh \
+  --config ./config.toml \
+  --port 22217 \
+  --name ds-free-api-test \
+  --skip-frontend \
+  --skip-build
+```
+
+`--skip-build` / `-SkipBuild` 复用上一次 Docker volume 中的 `target/debug/ds-free-api`。
+
+## 配置处理
+
+Docker 端口映射要求服务监听 `0.0.0.0`。脚本会复制传入的 `config.toml` 到 `target/docker-test-config.toml`，并只替换：
+
+```toml
+host = "127.0.0.1"
+```
+
+为：
+
+```toml
+host = "0.0.0.0"
+```
+
+原配置文件不会被修改。
+
+## 容器与缓存
+
+默认容器名：
+
+```text
+ds-free-api-test
+```
+
+默认 Docker volumes：
+
+```text
+ds-free-api-cargo-home
+ds-free-api-target
+ds-free-api-test-data
+```
+
+查看日志：
+
+```bash
+docker logs -f ds-free-api-test
+```
+
+停止测试容器：
+
+```bash
+docker rm -f ds-free-api-test
+```
+
+## 常见问题
+
+`/health` 正常但 `/admin` 404：
+
+```text
+web/dist 未挂载或未构建 → 运行脚本时不要传 --skip-frontend
+```
+
+apt 下载失败：
+
+```text
+脚本已设置清华源和 5 次重试；重新执行同一命令即可复用已下载缓存。
+```
+
+Cargo 下载慢：
+
+```text
+脚本在容器内写入 /usr/local/cargo/config.toml，使用 rsproxy sparse registry。
+```

--- a/scripts/dev-docker-run.ps1
+++ b/scripts/dev-docker-run.ps1
@@ -1,0 +1,134 @@
+param(
+    [string]$ConfigPath = "",
+    [int]$Port = 22217,
+    [string]$ContainerName = "ds-free-api-test",
+    [string]$Image = "rust:1.95.0-bookworm",
+    [switch]$SkipFrontend,
+    [switch]$SkipBuild,
+    [switch]$NoCacheVolumes
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoRoot {
+    $scriptDir = Split-Path -Parent $PSCommandPath
+    return (Resolve-Path (Join-Path $scriptDir "..")).Path
+}
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Missing command: $Name"
+    }
+}
+
+function To-DockerPath {
+    param([string]$Path)
+    $resolved = (Resolve-Path -LiteralPath $Path).Path
+    return $resolved -replace "\\", "/"
+}
+
+$repoRoot = Resolve-RepoRoot
+Set-Location $repoRoot
+
+Require-Command "docker"
+Require-Command "bun"
+
+if ([string]::IsNullOrWhiteSpace($ConfigPath)) {
+    $candidate = Join-Path $repoRoot "config.toml"
+    if (Test-Path -LiteralPath $candidate) {
+        $ConfigPath = $candidate
+    } else {
+        throw "ConfigPath is required when ./config.toml does not exist."
+    }
+}
+
+$ConfigPath = (Resolve-Path -LiteralPath $ConfigPath).Path
+
+if (-not $SkipFrontend) {
+    Push-Location (Join-Path $repoRoot "web")
+    try {
+        $env:BUN_CONFIG_REGISTRY = "https://registry.npmmirror.com"
+        bun install --frozen-lockfile
+        bun run build
+    } finally {
+        Pop-Location
+    }
+}
+
+$tmpConfig = Join-Path $repoRoot "target/docker-test-config.toml"
+New-Item -ItemType Directory -Force (Split-Path -Parent $tmpConfig) | Out-Null
+(Get-Content -LiteralPath $ConfigPath) `
+    -replace '^host\s*=\s*"127\.0\.0\.1"', 'host = "0.0.0.0"' `
+    -replace '^host\s*=\s*"localhost"', 'host = "0.0.0.0"' |
+    Set-Content -LiteralPath $tmpConfig -Encoding UTF8
+
+$cargoHome = "ds-free-api-cargo-home:/usr/local/cargo"
+$targetVolume = "ds-free-api-target:/work/target"
+if ($NoCacheVolumes) {
+    $cargoCachePath = To-DockerPath (Join-Path $repoRoot ".docker-cargo-home")
+    $targetPath = To-DockerPath (Join-Path $repoRoot "target")
+    $cargoHome = "${cargoCachePath}:/usr/local/cargo"
+    $targetVolume = "${targetPath}:/work/target"
+}
+
+$repoPath = To-DockerPath $repoRoot
+$webDistPath = To-DockerPath (Join-Path $repoRoot "web/dist")
+$tmpConfigPath = To-DockerPath $tmpConfig
+$repoMount = "${repoPath}:/work"
+$webDistMount = "${webDistPath}:/work/web/dist:ro"
+$configMount = "${tmpConfigPath}:/app/config/config.toml:ro"
+
+$buildScript = @'
+set -e
+sed -i \
+  -e 's|http://deb.debian.org/debian|https://mirrors.tuna.tsinghua.edu.cn/debian|g' \
+  -e 's|http://deb.debian.org/debian-security|https://mirrors.tuna.tsinghua.edu.cn/debian-security|g' \
+  /etc/apt/sources.list.d/debian.sources
+mkdir -p /usr/local/cargo
+cat > /usr/local/cargo/config.toml <<'EOF'
+[source.crates-io]
+replace-with = "rsproxy"
+
+[source.rsproxy]
+registry = "sparse+https://rsproxy.cn/index/"
+EOF
+apt-get -o Acquire::Retries=5 update
+apt-get -o Acquire::Retries=5 install -y --no-install-recommends cmake ninja-build libclang-dev
+/usr/local/cargo/bin/cargo build
+'@
+
+if (-not $SkipBuild) {
+    docker run --rm `
+        -v $repoMount `
+        -v $cargoHome `
+        -v $targetVolume `
+        -w /work `
+        $Image `
+        bash -c $buildScript
+}
+
+$existing = docker ps -aq --filter "name=^/$ContainerName$"
+if ($existing) {
+    docker rm -f $ContainerName | Out-Null
+}
+
+docker run -d `
+    --name $ContainerName `
+    -p "${Port}:22217" `
+    -v $targetVolume `
+    -v $webDistMount `
+    -v $configMount `
+    -v ds-free-api-test-data:/app/data `
+    -e RUST_LOG=info `
+    -e DS_DATA_DIR=/app/data `
+    -e DS_CONFIG_PATH=/app/config/config.toml `
+    -w /work `
+    $Image `
+    /work/target/debug/ds-free-api | Out-Null
+
+Start-Sleep -Seconds 3
+$health = Invoke-RestMethod -Uri "http://127.0.0.1:$Port/health" -TimeoutSec 10
+Write-Host "health: $($health | ConvertTo-Json -Compress)"
+Write-Host "admin:  http://127.0.0.1:$Port/admin"
+Write-Host "logs:   docker logs -f $ContainerName"

--- a/scripts/dev-docker-run.sh
+++ b/scripts/dev-docker-run.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_PATH=""
+PORT="22217"
+CONTAINER_NAME="ds-free-api-test"
+IMAGE="rust:1.95.0-bookworm"
+SKIP_FRONTEND="0"
+SKIP_BUILD="0"
+NO_CACHE_VOLUMES="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --name)
+      CONTAINER_NAME="$2"
+      shift 2
+      ;;
+    --image)
+      IMAGE="$2"
+      shift 2
+      ;;
+    --skip-frontend)
+      SKIP_FRONTEND="1"
+      shift
+      ;;
+    --skip-build)
+      SKIP_BUILD="1"
+      shift
+      ;;
+    --no-cache-volumes)
+      NO_CACHE_VOLUMES="1"
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/dev-docker-run.sh [options]
+
+Options:
+  --config PATH       config.toml path. Default: ./config.toml
+  --port PORT         host port. Default: 22217
+  --name NAME         container name. Default: ds-free-api-test
+  --image IMAGE       Rust image. Default: rust:1.95.0-bookworm
+  --skip-frontend     skip bun install/build
+  --skip-build        skip cargo build
+  --no-cache-volumes  use repo-local cache paths instead of Docker volumes
+EOF
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing command: $1" >&2
+    exit 1
+  fi
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+require_command docker
+require_command bun
+
+if [[ -z "$CONFIG_PATH" ]]; then
+  if [[ -f "$repo_root/config.toml" ]]; then
+    CONFIG_PATH="$repo_root/config.toml"
+  else
+    echo "config not specified and ./config.toml does not exist" >&2
+    exit 1
+  fi
+fi
+
+CONFIG_PATH="$(cd "$(dirname "$CONFIG_PATH")" && pwd)/$(basename "$CONFIG_PATH")"
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "config not found: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+if [[ "$SKIP_FRONTEND" != "1" ]]; then
+  (
+    cd "$repo_root/web"
+    export BUN_CONFIG_REGISTRY="https://registry.npmmirror.com"
+    bun install --frozen-lockfile
+    bun run build
+  )
+fi
+
+mkdir -p "$repo_root/target"
+TMP_CONFIG="$repo_root/target/docker-test-config.toml"
+sed \
+  -e 's/^host[[:space:]]*=[[:space:]]*"127\.0\.0\.1"/host = "0.0.0.0"/' \
+  -e 's/^host[[:space:]]*=[[:space:]]*"localhost"/host = "0.0.0.0"/' \
+  "$CONFIG_PATH" > "$TMP_CONFIG"
+
+if [[ "$NO_CACHE_VOLUMES" == "1" ]]; then
+  mkdir -p "$repo_root/.docker-cargo-home" "$repo_root/target"
+  CARGO_MOUNT="$repo_root/.docker-cargo-home:/usr/local/cargo"
+  TARGET_MOUNT="$repo_root/target:/work/target"
+else
+  CARGO_MOUNT="ds-free-api-cargo-home:/usr/local/cargo"
+  TARGET_MOUNT="ds-free-api-target:/work/target"
+fi
+
+read -r -d '' BUILD_SCRIPT <<'EOF' || true
+set -e
+sed -i \
+  -e 's|http://deb.debian.org/debian|https://mirrors.tuna.tsinghua.edu.cn/debian|g' \
+  -e 's|http://deb.debian.org/debian-security|https://mirrors.tuna.tsinghua.edu.cn/debian-security|g' \
+  /etc/apt/sources.list.d/debian.sources
+mkdir -p /usr/local/cargo
+cat > /usr/local/cargo/config.toml <<'CARGOEOF'
+[source.crates-io]
+replace-with = "rsproxy"
+
+[source.rsproxy]
+registry = "sparse+https://rsproxy.cn/index/"
+CARGOEOF
+apt-get -o Acquire::Retries=5 update
+apt-get -o Acquire::Retries=5 install -y --no-install-recommends cmake ninja-build libclang-dev
+/usr/local/cargo/bin/cargo build
+EOF
+
+if [[ "$SKIP_BUILD" != "1" ]]; then
+  docker run --rm \
+    -v "$repo_root:/work" \
+    -v "$CARGO_MOUNT" \
+    -v "$TARGET_MOUNT" \
+    -w /work \
+    "$IMAGE" \
+    bash -c "$BUILD_SCRIPT"
+fi
+
+if docker ps -aq --filter "name=^/${CONTAINER_NAME}$" | grep -q .; then
+  docker rm -f "$CONTAINER_NAME" >/dev/null
+fi
+
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p "$PORT:22217" \
+  -v "$TARGET_MOUNT" \
+  -v "$repo_root/web/dist:/work/web/dist:ro" \
+  -v "$TMP_CONFIG:/app/config/config.toml:ro" \
+  -v ds-free-api-test-data:/app/data \
+  -e RUST_LOG=info \
+  -e DS_DATA_DIR=/app/data \
+  -e DS_CONFIG_PATH=/app/config/config.toml \
+  -w /work \
+  "$IMAGE" \
+  /work/target/debug/ds-free-api >/dev/null
+
+sleep 3
+curl -fsS "http://127.0.0.1:$PORT/health"
+echo
+echo "admin: http://127.0.0.1:$PORT/admin"
+echo "logs:  docker logs -f $CONTAINER_NAME"

--- a/src/anthropic_compat/response/stream.rs
+++ b/src/anthropic_compat/response/stream.rs
@@ -286,7 +286,31 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
-                    return Poll::Ready(Some(Err(AnthropicCompatError::from(e))));
+                    if !this.state.started {
+                        return Poll::Ready(Some(Err(AnthropicCompatError::from(e))));
+                    }
+                    if !this.state.finished {
+                        debug!(
+                            target: "anthropic_compat::response::stream",
+                            "上游流错误后补齐 Anthropic 收尾事件: {}",
+                            e
+                        );
+                        this.state.finished = true;
+                        let mut events: Vec<MessagesResponseChunk> =
+                            this.state.transition_to(BlockKind::None);
+                        events.push(MessagesResponseChunk::MessageDelta {
+                            stop_reason: None,
+                            stop_sequence: None,
+                            output_tokens: Some(this.state.completion_tokens.unwrap_or(0)),
+                        });
+                        events.push(MessagesResponseChunk::MessageStop);
+                        this.pending_events.extend(events);
+                    }
+                    if !this.pending_events.is_empty() {
+                        let event = this.pending_events.remove(0);
+                        return Poll::Ready(Some(Ok(event)));
+                    }
+                    return Poll::Ready(None);
                 }
                 Poll::Ready(None) => {
                     debug!(target: "anthropic_compat::response::stream", "流结束, started={}, finished={}", this.state.started, this.state.finished);
@@ -487,6 +511,18 @@ mod tests {
         let mut events = Vec::new();
         while let Some(event) = anthropic.next().await {
             events.push(event.unwrap());
+        }
+        events
+    }
+
+    async fn collect_results(
+        chunks: Vec<Result<ChatCompletionsResponseChunk, OpenAIAdapterError>>,
+    ) -> Vec<Result<MessagesResponseChunk, crate::anthropic_compat::AnthropicCompatError>> {
+        let stream = futures::stream::iter(chunks);
+        let mut anthropic = super::from_chat_completion_stream(stream);
+        let mut events = Vec::new();
+        while let Some(event) = anthropic.next().await {
+            events.push(event);
         }
         events
     }
@@ -772,6 +808,21 @@ mod tests {
         if let MessagesResponseChunk::MessageDelta { stop_reason, .. } = &events[delta_idx] {
             assert_eq!(stop_reason, &None);
         }
+    }
+
+    #[tokio::test]
+    async fn upstream_error_after_start_sends_message_stop() {
+        let events = collect_results(vec![
+            Ok(role_chunk("deepseek-default", "chatcmpl-err")),
+            Ok(content_chunk("Hi")),
+            Err(OpenAIAdapterError::Internal("upstream interrupted".into())),
+        ])
+        .await;
+
+        assert!(events.iter().all(Result::is_ok));
+        let events: Vec<_> = events.into_iter().map(Result::unwrap).collect();
+        assert_eq!(events.last().unwrap().event_name(), "message_stop");
+        assert_eq!(events[events.len() - 2].event_name(), "message_delta");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- Harden Anthropic streaming conversion so an upstream OpenAI/DeepSeek stream error after `message_start` emits Anthropic close events instead of leaving Claude Code waiting forever.
- Add regression coverage for the started-stream interruption path.
- Add one-command Docker build/run scripts for Windows, Linux, and macOS with China mirror configuration for Bun, Cargo, and apt, plus usage docs.

## Why

Claude Code can keep waiting when the upstream stream is interrupted after the Anthropic message has already started but before a protocol-level stop event is emitted.

## Validation

- PowerShell parser and scriptblock syntax check: passed
- `bash -n scripts/dev-docker-run.sh`: passed
- `git diff --check`: passed, only Windows CRLF conversion warnings
- Docker Rust test: `cargo test --lib upstream_error_after_start_sends_message_stop` passed, 1 passed / 0 failed / 124 filtered out
