### PR TITLE
[codex] fix DeepSeek stream delta dedupe

### DIFF
--- a/src/openai_adapter/response/state.rs
+++ b/src/openai_adapter/response/state.rs
@@ -93,33 +93,40 @@ impl DsState {
             }
         } else if self.current_path.is_some() {
             let path = self.current_path.clone().unwrap();
-            frames.extend(self.apply_path(&path, Some("APPEND"), v));
+            frames.extend(self.apply_path(&path, None, v));
         } else {
-            // 无 current_path 的纯 v 视为初始 snapshot
+            // 无 current_path 的纯 v 视为 response snapshot，只输出相对旧状态的新后缀。
             if let Some(response) = v.get("response")
                 && let Some(arr) = response.get("fragments").and_then(|f| f.as_array())
             {
-                self.fragments.clear();
-                for frag in arr {
+                let mut next_fragments = Vec::new();
+                for (idx, frag) in arr.iter().enumerate() {
                     if let Some(ty) = frag.get("type").and_then(|t| t.as_str()) {
                         let content = frag
                             .get("content")
                             .and_then(|c| c.as_str())
                             .unwrap_or("")
                             .to_string();
-                        self.fragments.push(Fragment {
-                            ty: ty.to_string(),
-                            content: content.clone(),
-                        });
                         if !content.is_empty() {
-                            match ty {
-                                FRAG_THINK => frames.push(DsFrame::ThinkDelta(content)),
-                                FRAG_RESPONSE => frames.push(DsFrame::ContentDelta(content)),
-                                _ => {}
+                            let old = self.fragments.get(idx).map(|f| f.content.as_str());
+                            let delta = snapshot_delta(old, &content);
+                            if !delta.is_empty() {
+                                match ty {
+                                    FRAG_THINK => frames.push(DsFrame::ThinkDelta(delta.to_string())),
+                                    FRAG_RESPONSE => {
+                                        frames.push(DsFrame::ContentDelta(delta.to_string()))
+                                    }
+                                    _ => {}
+                                }
                             }
                         }
+                        next_fragments.push(Fragment {
+                            ty: ty.to_string(),
+                            content,
+                        });
                     }
                 }
+                self.fragments = next_fragments;
             }
         }
 
@@ -166,14 +173,34 @@ impl DsState {
                 if let Some(s) = val.as_str()
                     && let Some(frag) = self.fragments.last_mut()
                 {
+                    let is_snapshot = op != Some("APPEND") && looks_like_snapshot(&frag.content, s);
+                    let content = if is_snapshot {
+                        snapshot_delta(Some(&frag.content), s)
+                    } else if op == Some("APPEND") {
+                        append_delta(&frag.content, s)
+                    } else {
+                        s
+                    };
                     match frag.ty.as_str() {
                         FRAG_THINK => {
-                            frag.content.push_str(s);
-                            frames.push(DsFrame::ThinkDelta(s.to_string()));
+                            if is_snapshot {
+                                frag.content = s.to_string();
+                            } else if !content.is_empty() {
+                                frag.content.push_str(content);
+                            }
+                            if !content.is_empty() {
+                                frames.push(DsFrame::ThinkDelta(content.to_string()));
+                            }
                         }
                         FRAG_RESPONSE => {
-                            frag.content.push_str(s);
-                            frames.push(DsFrame::ContentDelta(s.to_string()));
+                            if is_snapshot {
+                                frag.content = s.to_string();
+                            } else if !content.is_empty() {
+                                frag.content.push_str(content);
+                            }
+                            if !content.is_empty() {
+                                frames.push(DsFrame::ContentDelta(content.to_string()));
+                            }
                         }
                         _ => {
                             // TOOL_SEARCH / TOOL_OPEN 等内部片段不映射到用户可见文本
@@ -190,14 +217,27 @@ impl DsState {
                                 .and_then(|c| c.as_str())
                                 .unwrap_or("")
                                 .to_string();
+                            let visible = if content.is_empty() {
+                                String::new()
+                            } else {
+                                let old = self
+                                    .fragments
+                                    .iter()
+                                    .rev()
+                                    .find(|f| f.ty == ty)
+                                    .map(|f| f.content.as_str());
+                                repeated_fragment_delta(old, &content).to_string()
+                            };
                             self.fragments.push(Fragment {
                                 ty: ty.to_string(),
-                                content: content.clone(),
+                                content,
                             });
-                            if !content.is_empty() {
+                            if !visible.is_empty() {
                                 match ty {
-                                    FRAG_THINK => frames.push(DsFrame::ThinkDelta(content)),
-                                    FRAG_RESPONSE => frames.push(DsFrame::ContentDelta(content)),
+                                    FRAG_THINK => frames.push(DsFrame::ThinkDelta(visible)),
+                                    FRAG_RESPONSE => {
+                                        frames.push(DsFrame::ContentDelta(visible))
+                                    }
                                     _ => {}
                                 }
                             }
@@ -209,6 +249,35 @@ impl DsState {
         }
 
         frames
+    }
+}
+
+fn looks_like_snapshot(old: &str, new: &str) -> bool {
+    new.starts_with(old) || old == new || old.contains(new)
+}
+
+fn append_delta<'a>(old: &str, new: &'a str) -> &'a str {
+    const REPLAY_MIN_CHARS: usize = 16;
+    if new.len() >= REPLAY_MIN_CHARS && old.ends_with(new) {
+        ""
+    } else {
+        new
+    }
+}
+
+fn repeated_fragment_delta<'a>(old: Option<&str>, new: &'a str) -> &'a str {
+    match old {
+        Some(prev) if prev == new => "",
+        Some(prev) => append_delta(prev, new),
+        None => new,
+    }
+}
+
+fn snapshot_delta<'a>(old: Option<&str>, new: &'a str) -> &'a str {
+    match old {
+        Some(prev) if looks_like_snapshot(prev, new) && new.starts_with(prev) => &new[prev.len()..],
+        Some(prev) if looks_like_snapshot(prev, new) => "",
+        _ => new,
     }
 }
 
@@ -335,6 +404,85 @@ mod tests {
         };
         let frames = state.apply_event(&evt);
         assert!(matches!(&frames[0], DsFrame::ThinkDelta(s) if s == "hi"));
+    }
+
+    #[test]
+    fn content_set_with_path_emits_only_new_suffix() {
+        let mut state = DsState::default();
+        state.fragments.push(Fragment {
+            ty: "RESPONSE".into(),
+            content: "hello".into(),
+        });
+        let evt = SseEvent {
+            event: None,
+            data: r#"{"p":"response/fragments/-1/content","v":"hello world"}"#.into(),
+        };
+        let frames = state.apply_event(&evt);
+        assert_eq!(frames.len(), 1);
+        assert!(matches!(&frames[0], DsFrame::ContentDelta(s) if s == " world"));
+    }
+
+    #[test]
+    fn content_path_without_op_keeps_append_when_not_snapshot() {
+        let mut state = DsState::default();
+        state.fragments.push(Fragment {
+            ty: "RESPONSE".into(),
+            content: "hello".into(),
+        });
+        let evt = SseEvent {
+            event: None,
+            data: r#"{"p":"response/fragments/-1/content","v":" world"}"#.into(),
+        };
+        let frames = state.apply_event(&evt);
+        assert_eq!(frames.len(), 1);
+        assert!(matches!(&frames[0], DsFrame::ContentDelta(s) if s == " world"));
+        assert_eq!(state.fragments[0].content, "hello world");
+    }
+
+    #[test]
+    fn repeated_append_chunk_is_ignored() {
+        let mut state = DsState::default();
+        state.fragments.push(Fragment {
+            ty: "RESPONSE".into(),
+            content: "prefix repeated repeated".into(),
+        });
+        let evt = SseEvent {
+            event: None,
+            data: r#"{"p":"response/fragments/-1/content","o":"APPEND","v":" repeated repeated"}"#.into(),
+        };
+        let frames = state.apply_event(&evt);
+        assert!(frames.is_empty());
+        assert_eq!(state.fragments[0].content, "prefix repeated repeated");
+    }
+
+    #[test]
+    fn repeated_fragment_append_initial_content_is_ignored() {
+        let mut state = DsState::default();
+        state.fragments.push(Fragment {
+            ty: "RESPONSE".into(),
+            content: "hello world".into(),
+        });
+        let evt = SseEvent {
+            event: None,
+            data: r#"{"p":"response/fragments","o":"APPEND","v":[{"type":"RESPONSE","content":"hello world"}]}"#.into(),
+        };
+        let frames = state.apply_event(&evt);
+        assert!(frames.is_empty());
+    }
+
+    #[test]
+    fn repeated_snapshot_does_not_reemit_content() {
+        let mut state = DsState::default();
+        let first = SseEvent {
+            event: None,
+            data: r#"{"v":{"response":{"fragments":[{"type":"RESPONSE","content":"hello"}]}}}"#.into(),
+        };
+        let second = first.clone();
+
+        let frames = state.apply_event(&first);
+        assert!(matches!(&frames[0], DsFrame::ContentDelta(s) if s == "hello"));
+        let frames = state.apply_event(&second);
+        assert!(frames.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Fix DeepSeek streaming replay by treating snapshot-like fragment updates as snapshots and emitting only new suffix content. Also suppresses repeated append fragments that would resend the same visible text through Feishu/OpenClaw streaming. Scope: only src/openai_adapter/response/state.rs. Validation: staged diff checked with git diff --cached --check; local Rust tests were not run because this machine is missing a usable Rust toolchain; Docker rebuild and /health check passed earlier.